### PR TITLE
KV i1871 - Handle timeout on remote connection

### DIFF
--- a/src/riak_kv_replrtq_peer.erl
+++ b/src/riak_kv_replrtq_peer.erl
@@ -143,7 +143,7 @@ handle_info({scheduled_discovery, QueueName}, State) ->
     Delay = rand:uniform(max(1, MaxDelay - MinDelay)) + MinDelay,
     _ = schedule_discovery(QueueName, self(), Delay),
     {noreply, State};
-handle_info({_Ref, HTTPClientError}, State) ->
+handle_info({Ref, {error, HTTPClientError}}, State) when is_reference(Ref) ->
     lager:info(
         "Client error caught - error ~p returned after timeout",
         [HTTPClientError]),

--- a/src/riak_kv_replrtq_peer.erl
+++ b/src/riak_kv_replrtq_peer.erl
@@ -66,7 +66,7 @@ update_discovery(QueueName) ->
         ?DISCOVERY_TIMEOUT_SECONDS * 1000).
 
 -spec update_workers(pos_integer(), pos_integer()) -> boolean().
-update_workers(WorkerCount, PerPeerLimit) ->
+update_workers(WorkerCount, PerPeerLimit) when PerPeerLimit =< WorkerCount ->
     gen_server:call(
         ?MODULE,
         {update_workers, WorkerCount, PerPeerLimit},

--- a/src/riak_kv_replrtq_peer.erl
+++ b/src/riak_kv_replrtq_peer.erl
@@ -142,6 +142,11 @@ handle_info({scheduled_discovery, QueueName}, State) ->
             ?AUTO_DISCOVERY_MAXIMUM_SECONDS),
     Delay = rand:uniform(max(1, MaxDelay - MinDelay)) + MinDelay,
     _ = schedule_discovery(QueueName, self(), Delay),
+    {noreply, State};
+handle_info({_Ref, HTTPClientError}, State) ->
+    lager:info(
+        "Client error caught - error ~p returned after timeout",
+        [HTTPClientError]),
     {noreply, State}.
 
 terminate(_Reason, _State) ->

--- a/src/riak_kv_replrtq_peer.erl
+++ b/src/riak_kv_replrtq_peer.erl
@@ -41,8 +41,8 @@
 -type discovery_peer() ::
     {riak_kv_replrtq_snk:queue_name(), [riak_kv_replrtq_snk:peer_info()]}.
 
--define(DISCOVERY_TIMEOUT_SECONDS, 60).
--define(UPDATE_TIMEOUT_SECONDS, 60).
+-define(DISCOVERY_TIMEOUT_SECONDS, 300).
+-define(UPDATE_TIMEOUT_SECONDS, 300).
 -define(AUTO_DISCOVERY_MAXIMUM_SECONDS, 900).
 -define(AUTO_DISCOVERY_MINIMUM_SECONDS, 60).
 

--- a/src/riak_kv_replrtq_snk.erl
+++ b/src/riak_kv_replrtq_snk.erl
@@ -223,7 +223,7 @@ add_snkqueue(
 %% Returns undefined if there are currently no peers defined.
 -spec current_peers(queue_name()) -> list(peer_info())|undefined.
 current_peers(QueueName) ->
-    gen_server:call(?MODULE, {current_peers, QueueName}).
+    gen_server:call(?MODULE, {current_peers, QueueName}, infinity).
 
 
 %% @doc


### PR DESCRIPTION
https://github.com/basho/riak_kv/issues/1871

The `riak_kv_replrtq_snk` will now determine the work to be run after initialisation - so the initial connection time of PB clients no longer delays the startup of riak_kv.

The `riak_kv_replrtq_snk` functions called by the `riak_kv_replrtq_peer` have timeouts disabled so that a `riak_kv_replrtq_snk` process which is hanging on a connection timeout does not crash a calling `riak_kv_replrtq_peer` process.

The `riak_kv_replrrtq_peer` will now catch and ignore replies from the erlang http client.  The client catches timeouts on calls to the connection process, so that when the connection process replies it goes to the process which launched the client.