### PR TITLE
Allow nextgenrepl to real-time replicate reaps

### DIFF
--- a/priv/riak_kv.schema
+++ b/priv/riak_kv.schema
@@ -1337,8 +1337,15 @@
     {default, "q1_ttaaefs:block_rtq"}
 ]}.
 
-%% @doc Enable this node zlib compress objects over the wire
+%% @doc Enable this node to zlib compress objects over the wire
 {mapping, "replrtq_compressonwire", "riak_kv.replrtq_compressonwire", [
+    {datatype, {flag, enabled, disabled}},
+    {default, disabled},
+    {commented, enabled}
+]}.
+
+%% @doc Enable this node to replicate reap requests to other clusters
+{mapping, "repl_reap", "riak_kv.repl_reap", [
     {datatype, {flag, enabled, disabled}},
     {default, disabled},
     {commented, enabled}

--- a/rebar.config
+++ b/rebar.config
@@ -53,5 +53,5 @@
     {riak_api, {git, "https://github.com/nhs-riak/riak_api.git", {branch, "nhse-develop-3.0"}}},
     {hyper, {git, "https://github.com/nhs-riak/hyper", {branch, "nhse-develop-3.0"}}},
     {kv_index_tictactree, {git, "https://github.com/nhs-riak/kv_index_tictactree.git", {branch, "nhse-develop-3.0"}}},
-    {riakhttpc, {git, "https://github.com/nhs-riak/riak-erlang-http-client", {branch, "nhse-d30-nhskv5"}}}
+    {riakhttpc, {git, "https://github.com/nhs-riak/riak-erlang-http-client", {branch, "nhse-develop-3.0"}}}
        ]}.

--- a/rebar.config
+++ b/rebar.config
@@ -53,5 +53,5 @@
     {riak_api, {git, "https://github.com/nhs-riak/riak_api.git", {branch, "nhse-develop-3.0"}}},
     {hyper, {git, "https://github.com/nhs-riak/hyper", {branch, "nhse-develop-3.0"}}},
     {kv_index_tictactree, {git, "https://github.com/nhs-riak/kv_index_tictactree.git", {branch, "nhse-develop-3.0"}}},
-    {riakhttpc, {git, "https://github.com/nhs-riak/riak-erlang-http-client", {branch, "nhse-develop-3.0"}}}
+    {riakhttpc, {git, "https://github.com/nhs-riak/riak-erlang-http-client", {branch, "nhse-d30-nhskv5"}}}
        ]}.

--- a/src/riak_kv_clusteraae_fsm.erl
+++ b/src/riak_kv_clusteraae_fsm.erl
@@ -585,8 +585,8 @@ json_encode_results(find_keys, Result) ->
     Keys = {struct, [{<<"results">>, [{struct, encode_find_key(Key, Int)} || {_Bucket, Key, Int} <- Result]}
                     ]},
     mochijson2:encode(Keys);
-json_encode_results(find_tombs, Result) ->
-    json_encode_results(find_keys, Result);
+json_encode_results(find_tombs, KeysNClocks) ->
+    encode_keys_and_clocks(KeysNClocks);
 json_encode_results(reap_tombs, Count) ->
     mochijson2:encode({struct, [{<<"dispatched_count">>, Count}]});
 json_encode_results(erase_keys, Count) ->
@@ -616,7 +616,7 @@ pb_encode_results(merge_branch_nval, _QD, Branches) ->
         level_two = L2
     };
 pb_encode_results(fetch_clocks_nval, _QD, KeysNClocks) ->
-     #rpbaaefoldkeyvalueresp{
+    #rpbaaefoldkeyvalueresp{
         response_type = atom_to_binary(clock, unicode),
         keys_value = lists:map(fun pb_encode_bucketkeyclock/1, KeysNClocks)};
 pb_encode_results(merge_tree_range, QD, Tree) ->
@@ -662,8 +662,10 @@ pb_encode_results(find_keys, _QD, Results) ->
         end,
     #rpbaaefoldkeycountresp{response_type = <<"find_keys">>, 
                             keys_count = lists:map(KeyCountMap, Results)};
-pb_encode_results(find_tombs, QD, Results) ->
-    pb_encode_results(find_keys, QD, Results);
+pb_encode_results(find_tombs, _QD, KeysNClocks) ->
+    #rpbaaefoldkeyvalueresp{
+        response_type = atom_to_binary(clock, unicode),
+        keys_value = lists:map(fun pb_encode_bucketkeyclock/1, KeysNClocks)};
 pb_encode_results(reap_tombs, _QD, Count) ->
     #rpbaaefoldkeycountresp{response_type = <<"reap_tombs">>, 
                             keys_count =

--- a/src/riak_kv_get_fsm.erl
+++ b/src/riak_kv_get_fsm.erl
@@ -237,6 +237,13 @@ queue_fetch(timeout, StateData) ->
             Msg = {ReqID, {ok, {deleted, ExpectedClock, Obj}}},
             Pid ! Msg,
             ok = riak_kv_stat:update(ngrfetch_prefetch),
+            {stop, normal, StateData};
+        {Bucket, Key, TombClock, {reap, LMD}} ->
+            % A reap request was queued - so there is no need to fetch
+            % A tombstone was queued - so there is no need to fetch
+            Msg = {ReqID, {ok, {reap, {Bucket, Key, TombClock, LMD}}}},
+            Pid ! Msg,
+            ok = riak_kv_stat:update(ngrfetch_prefetch),
             {stop, normal, StateData}
     end.
 

--- a/src/riak_kv_reaper.erl
+++ b/src/riak_kv_reaper.erl
@@ -63,7 +63,7 @@
             redo/0]).
 
 -type reap_reference() ::
-    {{riak_object:bucket(), riak_object:key()}, non_neg_integer()}.
+    {{riak_object:bucket(), riak_object:key()}, vclock:vclock(), boolean()}.
 -type job_id() :: pos_integer().
 
 -export_type([reap_reference/0, job_id/0]).
@@ -149,7 +149,7 @@ get_limits() ->
 %% we will not redo - redo is only to handle the failure related to unavailable
 %% primaries
 -spec action(reap_reference(), boolean()) -> boolean().
-action({{Bucket, Key}, DeleteHash}, Redo) ->
+action({{Bucket, Key}, TombClock, ToRepl}, Redo) ->
     BucketProps = riak_core_bucket:get_bucket(Bucket),
     DocIdx = riak_core_util:chash_key({Bucket, Key}, BucketProps),
     {n_val, N} = lists:keyfind(n_val, 1, BucketProps),
@@ -160,7 +160,11 @@ action({{Bucket, Key}, DeleteHash}, Redo) ->
             PL0 = lists:map(fun({Target, primary}) -> Target end, PrefList),
             case check_all_mailboxes(PL0) of
                 ok ->
-                    riak_kv_vnode:reap(PL0, {Bucket, Key}, DeleteHash),
+                    riak_kv_vnode:reap(
+                        PL0,
+                        {Bucket, Key},
+                        riak_object:delete_hash(TombClock)),
+                    maybe_repl_reap(Bucket, Key, TombClock, ToRepl),
                     timer:sleep(TombPause),
                     true;
                 soft_loaded ->
@@ -171,6 +175,7 @@ action({{Bucket, Key}, DeleteHash}, Redo) ->
             if Redo -> false; true -> true end
     end.
 
+
 -spec redo() -> boolean().
 redo() -> true.
 
@@ -179,6 +184,18 @@ redo() -> true.
 %%%============================================================================
 
 -type preflist_entry() :: {non_neg_integer(), node()}.
+
+-spec maybe_repl_reap(
+    riak_object:bucket(), riak_object:key(), vclock:vclock(), boolean()) -> ok.
+maybe_repl_reap(Bucket, Key, TombClock, ToReap) ->
+    case application:get_env(riak_kv, repl_reap, false) and ToReap of
+        true ->
+            riak_kv_replrtq_src:replrtq_reap(
+                Bucket, Key, TombClock, os:timestamp());
+        false ->
+            ok
+    end.
+
 
 %% Protect against overloading the system when not reaping should any
 %% mailbox be in soft overload state

--- a/src/riak_kv_reaper.erl
+++ b/src/riak_kv_reaper.erl
@@ -64,6 +64,11 @@
 
 -type reap_reference() ::
     {{riak_object:bucket(), riak_object:key()}, vclock:vclock(), boolean()}.
+    %% the reap reference is {Bucket, Key, Clock (of tombstone), Forward}.  The
+    %% Forward boolean() indicates if this reap should be replicated if
+    %% riak_kv.repl_reap is true.  When a reap is received via replication
+    %% Forward should be set to false, to prevent reaps from perpetually
+    %% circulating
 -type job_id() :: pos_integer().
 
 -export_type([reap_reference/0, job_id/0]).

--- a/src/riak_kv_replrtq_snk.erl
+++ b/src/riak_kv_replrtq_snk.erl
@@ -721,10 +721,10 @@ repl_fetcher(WorkItem) ->
                             {tomb, FetchSplit, PushSplit, ModSplit});
             {ok, RObj} ->
                 SWFetched = os:timestamp(),
+                {ok, LMD} = riak_client:push(RObj, false, [], LocalClient),
                 SWPushed = os:timestamp(),
                 FetchSplit = timer:now_diff(SWFetched, SW),
                 PushSplit = timer:now_diff(SWPushed, SWFetched),
-                {ok, LMD} = riak_client:push(RObj, false, [], LocalClient),
                 ModSplit =timer:now_diff(SWPushed, LMD),
                 ok = riak_kv_stat:update(ngrrepl_object),
                 done_work(WorkItem, true,

--- a/src/riak_kv_replrtq_snk.erl
+++ b/src/riak_kv_replrtq_snk.erl
@@ -139,10 +139,10 @@
     % Modified time by bucket - second, minute, hour, day, longer}
 
 -type reply_tuple() ::
-    {queue_empty, non_neg_integer()} |
-        {tomb, non_neg_integer(), non_neg_integer(), non_neg_integer()} |
-        {object, non_neg_integer(), non_neg_integer(), non_neg_integer()} |
-        {error, any(), any()}.
+    {queue_empty, non_neg_integer()}|
+    {tomb, non_neg_integer(), non_neg_integer(), non_neg_integer()}|
+    {object, non_neg_integer(), non_neg_integer(), non_neg_integer()}|
+    {error, any(), any()}.
 
 -export_type([peer_info/0, queue_name/0]).
 
@@ -721,11 +721,11 @@ repl_fetcher(WorkItem) ->
                             {tomb, FetchSplit, PushSplit, ModSplit});
             {ok, RObj} ->
                 SWFetched = os:timestamp(),
-                {ok, LMD} = riak_client:push(RObj, false, [], LocalClient),
                 SWPushed = os:timestamp(),
-                ModSplit = timer:now_diff(SWPushed, LMD),
                 FetchSplit = timer:now_diff(SWFetched, SW),
                 PushSplit = timer:now_diff(SWPushed, SWFetched),
+                {ok, LMD} = riak_client:push(RObj, false, [], LocalClient),
+                ModSplit =timer:now_diff(SWPushed, LMD),
                 ok = riak_kv_stat:update(ngrrepl_object),
                 done_work(WorkItem, true,
                             {object, FetchSplit, PushSplit, ModSplit});
@@ -750,9 +750,16 @@ repl_fetcher(WorkItem) ->
                 done_work(UpdWorkItem, false, {error, error, remote_error})
         end
     catch
-        Type:Exception ->
-            lager:warning("Snk worker failed at Peer ~w due to ~w error ~w",
-                            [Peer, Type, Exception]),
+        Type:Exception:Stk ->
+            lager:warning(
+                "Snk worker failed at Peer ~w due to ~w error ~w",
+                [Peer, Type, Exception]),
+            case app_helper:get_env(riak_kv, log_snk_stacktrace, false) of
+                true ->
+                    lager:warning("Snk worker failed due to ~p", [Stk]);
+                _ ->
+                    ok
+            end,
             RemoteFun(close),
             UpdWorkItem0 = setelement(3, WorkItem, RenewClientFun()),
             ok = riak_kv_stat:update(ngrrepl_error),
@@ -797,8 +804,9 @@ add_success({{success, Success}, F, FT, PT, RT, MT}) ->
 add_failure({S, {failure, Failure}, FT, PT, RT, MT}) ->
     {S, {failure, Failure + 1}, FT, PT, RT, MT}.
 
--spec add_repltime(queue_stats(),
-                    {integer(), integer(), integer()}) -> queue_stats().
+-spec add_repltime(
+    queue_stats(), {non_neg_integer(), non_neg_integer(), non_neg_integer()})
+    -> queue_stats().
 add_repltime({S, 
                 F,
                 {replfetch_time, FT}, {replpush_time, PT}, {replmod_time, RT},
@@ -810,7 +818,7 @@ add_repltime({S,
         {replmod_time, RT + RT0},
         MT}.
 
--spec add_modtime(queue_stats(), integer()) -> queue_stats().
+-spec add_modtime(queue_stats(), non_neg_integer()) -> queue_stats().
 add_modtime({S, F, FT, PT, RT, MT}, ModTime) ->
     E = mod_split_element(ModTime div 1000) +  1,
     C = element(E, MT),

--- a/src/riak_kv_replrtq_snk.erl
+++ b/src/riak_kv_replrtq_snk.erl
@@ -725,7 +725,7 @@ repl_fetcher(WorkItem) ->
                 SWPushed = os:timestamp(),
                 FetchSplit = timer:now_diff(SWFetched, SW),
                 PushSplit = timer:now_diff(SWPushed, SWFetched),
-                ModSplit =timer:now_diff(SWPushed, LMD),
+                ModSplit = timer:now_diff(SWPushed, LMD),
                 ok = riak_kv_stat:update(ngrrepl_object),
                 done_work(WorkItem, true,
                             {object, FetchSplit, PushSplit, ModSplit});

--- a/src/riak_object.erl
+++ b/src/riak_object.erl
@@ -1189,23 +1189,25 @@ binary_version(<<131,_/binary>>) -> v0;
 binary_version(<<?MAGIC:8/integer, 1:8/integer, _/binary>>) -> v1.
 
 %% @doc Encode for nextgen_repl
--spec nextgenrepl_encode(repl_v1, riak_object(), boolean()) -> binary().
+-spec nextgenrepl_encode(
+    repl_v1,
+    riak_object()|
+        {reap,
+            {riak_object:bucket(), riak_object:key(),
+            vclock:vclock(), erlang:timestamp()}},
+    boolean()) -> binary().
+nextgenrepl_encode(repl_v1, {reap, {B, K, TC, LMD}}, _ToCompress) ->
+    ObjBK = nextgenrepl_binarykey(B, K),
+    TCBin = term_to_binary(TC),
+    {Mega, Secs, Micro} = LMD,
+    <<1:4/integer, 0:1/integer, 1:1/integer, 0:2/integer,
+        ObjBK/binary,
+        Mega:32/integer, Secs:32/integer, Micro:32/integer,
+        TCBin/binary>>;
 nextgenrepl_encode(repl_v1, RObj, ToCompress) ->
     B = riak_object:bucket(RObj),
     K = riak_object:key(RObj),
-    KS = byte_size(K),
-    ObjBK =
-        case B of
-            {T, B0} ->
-                TS = byte_size(T),
-                B0S = byte_size(B0),
-                <<TS:32/integer, T/binary, B0S:32/integer, B0/binary,
-                    KS:32/integer, K/binary>>;
-            B0 ->
-                B0S = byte_size(B0),
-                <<0:32/integer, B0S:32/integer, B0/binary,
-                    KS:32/integer, K/binary>>
-        end,
+    ObjBK = nextgenrepl_binarykey(B, K),
     {Version, ObjBin} =
         case ToCompress of
             true ->
@@ -1217,22 +1219,45 @@ nextgenrepl_encode(repl_v1, RObj, ToCompress) ->
         end,
     <<Version/binary, ObjBK/binary, ObjBin/binary>>.
 
-%% @doc Deocde for nextgen_repl
--spec nextgenrepl_decode(binary()) -> riak_object().
-nextgenrepl_decode(<<1:4/integer, C:1/integer, _:3/integer,
+-spec nextgenrepl_binarykey(
+    riak_object:bucket(), riak_object:key()) -> binary().
+nextgenrepl_binarykey({T, B}, K) ->
+    TS = byte_size(T),
+    BS = byte_size(B),
+    KS = byte_size(K),
+    <<TS:32/integer, T/binary,
+        BS:32/integer, B/binary,
+        KS:32/integer, K/binary>>;
+nextgenrepl_binarykey(B, K) ->
+    BS = byte_size(B),
+    KS = byte_size(K),
+    <<0:32/integer, BS:32/integer, B/binary, KS:32/integer, K/binary>>.
+
+%% @doc Deocde for nextgenrepl
+-spec nextgenrepl_decode(
+    binary()) ->
+        riak_object()|
+        {reap,
+            {riak_object:bucket(), riak_object:key(),
+                vclock:vclock(), erlang:timestamp()}}.
+nextgenrepl_decode(<<1:4/integer, C:1/integer, R:1/integer, _:2/integer,
                         0:32/integer, BL:32/integer, B:BL/binary,
                         KL:32/integer, K:KL/binary,
                         ObjBin/binary>>) ->
-    nextgenrepl_decode(B, K, C == 1, ObjBin);
-nextgenrepl_decode(<<1:4/integer, C:1/integer, _:3/integer,
+    nextgenrepl_decode(B, K, C == 1, R == 1, ObjBin);
+nextgenrepl_decode(<<1:4/integer, C:1/integer, R:1/integer, _:2/integer,
                         TL:32/integer, T:TL/binary, BL:32/integer, B:BL/binary,
                         KL:32/integer, K:KL/binary,
                         ObjBin/binary>>) ->
-    nextgenrepl_decode({T, B}, K, C == 1, ObjBin).
+    nextgenrepl_decode({T, B}, K, C == 1, R == 1, ObjBin).
 
-nextgenrepl_decode(B, K, true, ObjBin) ->
-    nextgenrepl_decode(B, K, false, zlib:uncompress(ObjBin));
-nextgenrepl_decode(B, K, false, ObjBin) ->
+nextgenrepl_decode(B, K, _, true, MetaBin) ->
+    <<Mega:32/integer, Secs:32/integer, Micro:32/integer, TClockBin/binary>> =
+        MetaBin,
+    {reap, {B, K, binary_to_term(TClockBin), {Mega, Secs, Micro}}};
+nextgenrepl_decode(B, K, true, false, ObjBin) ->
+    nextgenrepl_decode(B, K, false, false, zlib:uncompress(ObjBin));
+nextgenrepl_decode(B, K, false, false, ObjBin) ->
     riak_object:from_binary(B, K, ObjBin).
 
 %% @doc Convert binary object to riak object
@@ -2257,7 +2282,17 @@ nextgenrepl() ->
     ACZ = riak_object:reconcile([A, C, Z], true),
     ACZ0 = nextgenrepl_decode(nextgenrepl_encode(repl_v1, ACZ, false)),
     ACZ0 = nextgenrepl_decode(nextgenrepl_encode(repl_v1, ACZ, true)),
-    ?assertEqual(ACZ0, ACZ).
+    ?assertEqual(ACZ, ACZ0),
+    LMD = os:timestamp(),
+    {reap, {B, K, ACZ1, LMD}} =
+        nextgenrepl_decode(
+            nextgenrepl_encode(repl_v1, {reap, {B, K, ACZ, LMD}}, false)),
+    {reap, {B, K, ACZ1, LMD}} =
+        nextgenrepl_decode(
+            nextgenrepl_encode(repl_v1, {reap, {B, K, ACZ, LMD}}, true)),
+    ?assertEqual(ACZ, ACZ1).
+
+
 
 
 verify_contents([], []) ->

--- a/src/riak_object.erl
+++ b/src/riak_object.erl
@@ -1188,14 +1188,14 @@ to_binary_version(Vsn, _B, _K, Obj = #r_object{}) ->
 binary_version(<<131,_/binary>>) -> v0;
 binary_version(<<?MAGIC:8/integer, 1:8/integer, _/binary>>) -> v1.
 
+-type repl_ref() ::
+    {reap,
+        {riak_object:bucket(), riak_object:key(),
+            vclock:vclock(), erlang:timestamp()}}.
+
 %% @doc Encode for nextgen_repl
 -spec nextgenrepl_encode(
-    repl_v1,
-    riak_object()|
-        {reap,
-            {riak_object:bucket(), riak_object:key(),
-            vclock:vclock(), erlang:timestamp()}},
-    boolean()) -> binary().
+    repl_v1, riak_object()|repl_ref(), boolean()) -> binary().
 nextgenrepl_encode(repl_v1, {reap, {B, K, TC, LMD}}, _ToCompress) ->
     ObjBK = nextgenrepl_binarykey(B, K),
     TCBin = term_to_binary(TC),
@@ -1234,12 +1234,7 @@ nextgenrepl_binarykey(B, K) ->
     <<0:32/integer, BS:32/integer, B/binary, KS:32/integer, K/binary>>.
 
 %% @doc Deocde for nextgenrepl
--spec nextgenrepl_decode(
-    binary()) ->
-        riak_object()|
-        {reap,
-            {riak_object:bucket(), riak_object:key(),
-                vclock:vclock(), erlang:timestamp()}}.
+-spec nextgenrepl_decode(binary()) -> riak_object()|repl_ref().
 nextgenrepl_decode(<<1:4/integer, C:1/integer, R:1/integer, _:2/integer,
                         0:32/integer, BL:32/integer, B:BL/binary,
                         KL:32/integer, K:KL/binary,


### PR DESCRIPTION
This is to address the issue of reaping across sync'd clusters.  Without this feature it is necessary to disable full-sync whilst independently replicating on each cluster.

Now if reaping via riak_kv_reaper the reap will be replicated assuming the `riak_kv.repl_reap` flag has been enabled.  At the receiving cluster the reap will not be replicated any further.

There are some API changes to support this.  The `find_tombs` aae_fold will now return Keys/Clocks and not Keys/DeleteHash.  The ReapReference for riak_kv_repaer will now expect a clock (version vector) not a DeleteHash, and will also now expect an additional boolean to indicate if this repl is a replication candidate (it will be false for all pushed reaps).

The object encoding for nextgenrepl now has a flag to indicate a reap, with a special encoding for reap references.