### PR TITLE
Add support for v0 object in parallel-mode AAE

### DIFF
--- a/src/riak_object.erl
+++ b/src/riak_object.erl
@@ -1282,21 +1282,21 @@ from_binary(_B, _K, Obj = #r_object{}) ->
     Obj.
 
 
--spec summary_from_binary(binary()) -> 
+-spec summary_from_binary(binary()|riak_object()) -> 
         {vclock:vclock(), integer(), integer(),
             list(erlang:timestamp())|undefined, binary()}.
 %% @doc
 %% Extract only sumarry infromation from the binary - the vector, the object 
 %% size and the sibling count
-summary_from_binary(<<131, _Rest/binary>>=ObjBin) ->
-    case binary_to_term(ObjBin) of
+summary_from_binary(<<?MAGIC, _Rest/binary>>=ObjBin) ->
+    summary_from_binary(ObjBin, byte_size(ObjBin));
+summary_from_binary(TermToBin) when is_binary(TermToBin) ->
+    case binary_to_term(TermToBin) of
         {proxy_object, HeadBin, ObjSize, _Fetcher} ->
             summary_from_binary(HeadBin, ObjSize);
         Objv0 ->
             summary_from_binary(Objv0)
     end;
-summary_from_binary(ObjBin) when is_binary(ObjBin) ->
-    summary_from_binary(ObjBin, byte_size(ObjBin));
 summary_from_binary(Object = #r_object{}) ->
     % Unexpected scenario but included for parity with from_binary
     % Calculating object size is expensive (relatively to other branches)

--- a/src/riak_object.erl
+++ b/src/riak_object.erl
@@ -1286,7 +1286,7 @@ from_binary(_B, _K, Obj = #r_object{}) ->
         {vclock:vclock(), integer(), integer(),
             list(erlang:timestamp())|undefined, binary()}.
 %% @doc
-%% Extract only sumarry infromation from the binary - the vector, the object 
+%% Extract only summary information from the binary - the vector, the object 
 %% size and the sibling count
 summary_from_binary(<<?MAGIC, _Rest/binary>>=ObjBin) ->
     summary_from_binary(ObjBin, byte_size(ObjBin));

--- a/src/riak_object.erl
+++ b/src/riak_object.erl
@@ -1289,13 +1289,11 @@ from_binary(_B, _K, Obj = #r_object{}) ->
 %% Extract only sumarry infromation from the binary - the vector, the object 
 %% size and the sibling count
 summary_from_binary(<<131, _Rest/binary>>=ObjBin) ->
-    case binary_to_term(ObjBin) of 
+    case binary_to_term(ObjBin) of
         {proxy_object, HeadBin, ObjSize, _Fetcher} ->
             summary_from_binary(HeadBin, ObjSize);
-        T ->
-            {vclock(T), byte_size(ObjBin), value_count(T),
-                undefined, <<>>}
-            % Legacy object version will end up with dummy details
+        Objv0 ->
+            summary_from_binary(Objv0)
     end;
 summary_from_binary(ObjBin) when is_binary(ObjBin) ->
     summary_from_binary(ObjBin, byte_size(ObjBin));


### PR DESCRIPTION
Cannot assume that v0 objects will not happen - as capability will negotiate down to v0 on Riak during failure scenarios (even when version >= 3.0).

This change will therefore ensure that parallel mode AAE can decode v0 objects, so that they will be indexed correctly wrt Last-Modified-Date.

https://github.com/basho/riak_kv/issues/1874