### PR TITLE
Update riak_kv_ttaaefs_manager.erl

### DIFF
--- a/src/riak_kv_ttaaefs_manager.erl
+++ b/src/riak_kv_ttaaefs_manager.erl
@@ -408,7 +408,8 @@ handle_cast({reply_complete, ReqID, Result}, State) ->
                 riak_kv_stat:update({ttaaefs, sync_fail, Duration}),
                 {?CRASH_TIMEOUT, State#state{previous_success = false}};
             {SyncState, 0} when SyncState == root_compare;
-                                SyncState == branch_compare ->
+                                SyncState == branch_compare;
+                                SyncState == tree_compare ->
                 riak_kv_stat:update({ttaaefs, sync_sync, Duration}),
                 lager:info("exchange=~w complete result=~w in duration=~w s" ++
                                     " sync_state=true",


### PR DESCRIPTION
For bucket-based full-sync `{tree_compare, 0}` is the return on success.