### PR TITLE
Use close_group

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -42,7 +42,8 @@
 ]}.
 
 {deps, [
-    {riak_core, {git, "https://github.com/nhs-riak/riak_core.git", {branch, "nhse-develop"}}},
+    {riak_core, {git, "https://github.com/nhs-riak/riak_core.git", {branch, "nhse-d32-nhscore1"}}},
+    {leveled, {git, "https://github.com/martinsumner/leveled.git", {branch, "mas-d31-i413"}}},
     {sidejob, {git, "https://github.com/nhs-riak/sidejob.git", {branch, "nhse-develop"}}},
     {bitcask, {git, "https://github.com/nhs-riak/bitcask.git", {branch, "nhse-develop"}}},
     {redbug, {git, "https://github.com/massemanet/redbug", {branch, "master"}}},

--- a/src/riak_kv_index_hashtree.erl
+++ b/src/riak_kv_index_hashtree.erl
@@ -1187,10 +1187,10 @@ close_trees(#state{trees=Trees} = State, true) ->
     really_close_trees(Trees, State).
 
 really_close_trees(Trees, State) ->
-    lists:foreach(fun really_close_tree/1, Trees),
+    hashtree:close_group(lists:map(fun({_Idx, Tree}) -> Tree end, Trees)),
     State#state{trees = undefined}.
 
-really_close_tree({_IdxN, Tree}) -> hashtree:close(Tree).
+
 
 -spec get_all_locks(build | rehash | upgrade, index(), pid()) -> boolean().
 get_all_locks(Type, Index, Pid) ->


### PR DESCRIPTION
Allows more structured shutdown when tree stores have leveled backend.  Depends on https://github.com/nhs-riak/riak_core/pull/2