### PR TITLE
Nhse d32 nhskv.i16

### DIFF
--- a/src/riak_kv_leveled_backend.erl
+++ b/src/riak_kv_leveled_backend.erl
@@ -606,13 +606,36 @@ status(_State) ->
     % mean an immediate response (and how frequently is this called?)
     [].
 
-%% @doc Get the data_size for this leveled backend
--spec data_size(state()) -> undefined | {non_neg_integer(), objects}.
-data_size(_State) ->
-    % TODO: not yet implemented
-    % We can run the bucket stats query getting all stats, but this would not
-    % mean an immediate response (and how frequently is this called?)
-    undefined.
+%% @doc Get an estimate of the data_size for this leveled backend
+-spec data_size(state()) ->
+    undefined |
+    {non_neg_integer(), objects} |
+    {fun(() -> {non_neg_integer(), objects}), dynamic}.
+data_size(#state{bookie=Bookie}) ->
+    TictacTreeSize = 1024 * 1024,
+    %% There are 1024 * 1024 hashes in the tree, but only the trailing 15 bits
+    %% of each hash are of interest in the leveled backend. This means there
+    %% are 32 * 1024 unique segments in the backend - so taking 32 unique
+    %% segments will result in counting 1 in 1024 keys.
+    %% Normally segment_lists are used in aae_folds, and they filter after the
+    %% key has been returned using the full segment - but we have no filter
+    %% here.  So 1 segment is 1:(128 * 256) not 1:(1024 * 1024) 
+    %% See leveled perf_SUITE tests
+    RandomSegment = rand:uniform(TictacTreeSize - 32) - 1,
+    F =
+        fun() ->
+            {async, DataSizeGuesser} =
+                leveled_bookie:book_headfold(
+                    Bookie,
+                    ?RIAK_TAG,
+                    {fun(_B, _K, _V, AccC) ->  AccC + 1024 end, 0},
+                    false,
+                    true,
+                    lists:seq(RandomSegment, RandomSegment + 31)
+                ),
+            {DataSizeGuesser(), objects}
+        end,
+    {F, dynamic}.
 
 
 %% @doc Register an asynchronous callback


### PR DESCRIPTION
Allows for transfers to show percentage progress:

```
'dev6@127.0.0.1' waiting to handoff 3 partitions

Active Transfers:

transfer type: ownership
vnode type: riak_kv_vnode
partition: 502391187832497878132516661246222288006726811648
started: 2024-01-30 14:15:46 [5.96 s ago]
last update: 2024-01-30 14:15:50 [1.90 s ago]
total size: 194560 objects
objects transferred: 34068

                         8392 Objs/s                          
     dev2@127.0.0.1        =======>       dev6@127.0.0.1      
        |=======                                    |  17%    
                          2.05 MB/s                           

transfer type: ownership
vnode type: riak_kv_vnode
partition: 730750818665451459101842416358141509827966271488
started: 2024-01-30 14:15:46 [5.94 s ago]
last update: 2024-01-30 14:15:50 [1.91 s ago]
total size: 181248 objects
objects transferred: 33567

                         8328 Objs/s                          
     dev2@127.0.0.1        =======>       dev6@127.0.0.1      
        |=======                                    |  18%    
                          2.03 MB/s                           


ok

'dev6@127.0.0.1' waiting to handoff 3 partitions

Active Transfers:

transfer type: ownership
vnode type: riak_kv_vnode
partition: 502391187832497878132516661246222288006726811648
started: 2024-01-30 14:15:46 [13.67 s ago]
last update: 2024-01-30 14:15:59 [1.44 s ago]
total size: 194560 objects
objects transferred: 102705

                         8394 Objs/s                          
     dev2@127.0.0.1        =======>       dev6@127.0.0.1      
        |======================                     |  52%    
                          2.05 MB/s                           

transfer type: ownership
vnode type: riak_kv_vnode
partition: 730750818665451459101842416358141509827966271488
started: 2024-01-30 14:15:46 [13.66 s ago]
last update: 2024-01-30 14:15:58 [1.57 s ago]
total size: 181248 objects
objects transferred: 101202

                         8365 Objs/s                          
     dev2@127.0.0.1        =======>       dev6@127.0.0.1      
        |========================                   |  55%    
                          2.04 MB/s                           


ok
```