### PR TITLE
Check KV ready before starting nextgenrepl

### DIFF
--- a/src/riak_kv_replrtq_snk.erl
+++ b/src/riak_kv_replrtq_snk.erl
@@ -68,7 +68,6 @@
 -define(STARTING_DELAYMS, 8).
 -define(MAX_SUCCESS_DELAYMS, 1024).
 -define(ON_ERROR_DELAYMS, 65536).
--define(INITIAL_TIMEOUT_MS, 60000).
 -define(DEFAULT_WORKERCOUNT, 1).
 
 -record(sink_work, {queue_name :: queue_name(),
@@ -420,9 +419,10 @@ handle_info(deferred_start, State) ->
             ?LOG_INFO(
                 "Real-time repl sink waiting ~w ms "
                 "to initialise as riak_kv not ready",
-                [?INITIAL_TIMEOUT_MS]
+                [riak_kv_util:ngr_initial_timeout()]
             ),
-            erlang:send_after(?INITIAL_TIMEOUT_MS, self(), deferred_start)
+            erlang:send_after(
+                riak_kv_util:ngr_initial_timeout(), self(), deferred_start)
     end,
     {noreply, State};
 handle_info(log_stats, State) ->
@@ -464,7 +464,8 @@ handle_continue(initialise_work, State) ->
             {SnkQueueName, Iteration, SnkW}
         end,
     Work = lists:map(MapPeerInfoFun, SnkQueuePeerInfo),
-    erlang:send_after(?INITIAL_TIMEOUT_MS, self(), deferred_start),
+    erlang:send_after(
+        riak_kv_util:ngr_initial_timeout(), self(), deferred_start),
     {noreply, State#state{enabled = true, work = Work}}.
 
 terminate(_Reason, State) ->

--- a/src/riak_kv_util.erl
+++ b/src/riak_kv_util.erl
@@ -51,7 +51,8 @@
         get_backend_config/3,
         is_modfun_allowed/2,
         shuffle_list/1,
-        kv_ready/0
+        kv_ready/0,
+        ngr_initial_timeout/0
     ]).
 -export([report_hashtree_tokens/0, reset_hashtree_tokens/2]).
 
@@ -219,6 +220,13 @@ get_write_once(Bucket) ->
 -spec kv_ready() -> boolean().
 kv_ready() ->
     lists:member(riak_kv, riak_core_node_watcher:services(node())).
+
+%% @doc
+%% Replication services may wait a period on startup to ensure stability before
+%% commencing.  Default 60s.  Normally only modified in test.
+-spec ngr_initial_timeout() -> pos_integer().
+ngr_initial_timeout() ->
+    application:get_env(riak_kv, ngr_initial_timeout, 60000).
 
 %% ===================================================================
 %% Hashtree token management functions

--- a/src/riak_kv_util.erl
+++ b/src/riak_kv_util.erl
@@ -50,7 +50,9 @@
         overload_reply/1,
         get_backend_config/3,
         is_modfun_allowed/2,
-        shuffle_list/1]).
+        shuffle_list/1,
+        kv_ready/0
+    ]).
 -export([report_hashtree_tokens/0, reset_hashtree_tokens/2]).
 
 -include_lib("kernel/include/logger.hrl").
@@ -214,7 +216,9 @@ get_write_once(Bucket) ->
             Err
     end.
 
-
+-spec kv_ready() -> boolean().
+kv_ready() ->
+    lists:member(riak_kv, riak_core_node_watcher:services(node())).
 
 %% ===================================================================
 %% Hashtree token management functions


### PR DESCRIPTION
If riak_kv is not ready, and `riak_kv_replrtq_snk` starts work it will fetch from queues on the remote cluster, but not be able to put those changes into this cluster.

This defers the prompting of work on startup until after riak_kv is ready.  The `riak_kv_replrtq_peer` can also prompt work - so this too  is delayed until riak_kv has started.

The `riak_kv_ttaaefs_manager` will not function correctly without riak_kv being started, so this also has startup deferred should riak_kv not be ready after the initial startup timeout.