### PR TITLE
Move strong conditional check to FSM

### DIFF
--- a/src/riak_client.erl
+++ b/src/riak_client.erl
@@ -58,7 +58,6 @@
 %% @type default_timeout() = 60000
 -define(DEFAULT_TIMEOUT, 60000).
 -define(DEFAULT_FOLD_TIMEOUT, 3600000).
--define(DEFAULT_ERRTOL, 0.00003).
 
 %% TODO: This type needs to be better specified and validated against
 %%       any dependents on riak_kv.


### PR DESCRIPTION
If the strong conditional check is at the API - becomes much harder to make the check identically and reliably in the HTTP API.

Webmachine has lots of potential exit points outside of our control - so it is hard to reliably release a session on exit.