### PR TITLE
Correct types on get_modstate/1

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -47,7 +47,7 @@
     {redbug, {git, "https://github.com/massemanet/redbug", {branch, "master"}}},
     {recon, {git, "https://github.com/ferd/recon", {tag, "2.5.5"}}},
     {sext, {git, "https://github.com/uwiger/sext.git", {tag, "1.8.0"}}},
-    {riak_pipe, {git, "https://github.com/nhs-riak/riak_pipe.git", {branch, "nhse-develop"}}},
+    {riak_pipe, {git, "https://github.com/nhs-riak/riak_pipe.git", {branch, "nhse-develop-3.4"}}},
     {riak_dt, {git, "https://github.com/nhs-riak/riak_dt.git", {branch, "nhse-develop"}}},
     {riak_api, {git, "https://github.com/nhs-riak/riak_api.git", {branch, "nhse-develop-3.4"}}},
     {hyper, {git, "https://github.com/nhs-riak/hyper", {branch, "nhse-develop"}}},

--- a/src/riak_kv_vnode.erl
+++ b/src/riak_kv_vnode.erl
@@ -507,7 +507,7 @@ when_loading_complete(AAECntrl, Preflists, PreflistFun, OnlyIfBroken) ->
 
 
 %% @doc Reveal the underlying module state for testing
--spec(get_modstate(state()) -> {atom(), state()}).
+-spec get_modstate(state()) -> {module(), term()}.
 get_modstate(_State=#state{mod=Mod, modstate=ModState}) ->
     {Mod, ModState}.
 


### PR DESCRIPTION
There is no pre-determined type for the backend module state.