### PR TITLE
Allow for tree format to be pinned back to previous version

### DIFF
--- a/priv/riak_kv.schema
+++ b/priv/riak_kv.schema
@@ -41,6 +41,16 @@
   {commented, enabled}
 ]}.
 
+%% @doc Use legacy-format tictac tree
+%% Should only be required when perfoming a rolling upgrade to 3.4.0 or 3.2.3,
+%% and using per-bucket full-sync.
+%% Temporary option - will be removed in 3.6
+{mapping, "legacyformat_tictacaae_tree", "riak_kv.legacyformat_tictacaae_tree", [
+  {datatype, {flag, enabled, disabled}},
+  {default, disabled},
+  hidden
+]}.
+
 %% @doc A path under which aae data files will be stored.
 {mapping, "tictacaae_dataroot", "riak_kv.tictacaae_dataroot", [
   {default, "$(platform_data_dir)/tictac_aae"},

--- a/src/riak_kv_clusteraae_fsm.erl
+++ b/src/riak_kv_clusteraae_fsm.erl
@@ -393,7 +393,7 @@ init(From={_, _, _}, [Query, Timeout]) ->
                                 riak_kv, legacyformat_tictacaae_tree, false
                             ),
                         leveled_tictac:new_tree(
-                            range_tree, TreeSize, UseLegacyTree
+                            range_tree, TreeSize, not UseLegacyTree
                         );
                     repl_keys_range ->
                         {[], 0, element(5, Query), ?REPL_BATCH_SIZE};

--- a/src/riak_kv_clusteraae_fsm.erl
+++ b/src/riak_kv_clusteraae_fsm.erl
@@ -388,7 +388,13 @@ init(From={_, _, _}, [Query, Timeout]) ->
                                     element(3, Query));
                     merge_tree_range ->
                         TreeSize = element(4, Query),
-                        leveled_tictac:new_tree(range_tree, TreeSize);
+                        UseLegacyTree =
+                            application:get_env(
+                                riak_kv, legacyformat_tictacaae_tree, false
+                            ),
+                        leveled_tictac:new_tree(
+                            range_tree, TreeSize, UseLegacyTree
+                        );
                     repl_keys_range ->
                         {[], 0, element(5, Query), ?REPL_BATCH_SIZE};
                     repair_keys_range ->
@@ -1001,11 +1007,12 @@ json_encode_tictac_empty_test() ->
     ?assertMatch([], leveled_tictac:find_dirtyleaves(Tree, ReverseTree)).
 
 json_encode_tictac_withentries_test() ->
-    encode_results_ofsize(small),
-    encode_results_ofsize(large).
+    encode_results_ofsize(small, true),
+    encode_results_ofsize(large, false),
+    encode_results_ofsize(large, true).
 
-encode_results_ofsize(TreeSize) ->
-    Tree = leveled_tictac:new_tree(tictac_folder_test, TreeSize),
+encode_results_ofsize(TreeSize, MapBasedTree) ->
+    Tree = leveled_tictac:new_tree(tictac_folder_test, TreeSize, MapBasedTree),
     ExtractFun = fun(K, V) -> {K, V} end,
     FoldFun = 
         fun({Key, Value}, AccTree) ->


### PR DESCRIPTION
Maybe required when using per-bucket AAE in a rolling upgrade.

This could be achieved using riak_core_capability, but as it is a one-off need with a relatively minor impact in a small subset of configurations, allow it be managed through manual configuration instead.  This makes the removal easier as well (the history of riak_core_capability is that some temporary changes can have end up with a long-term presence in the code). 