### PR TITLE
Add support for new Query API

### DIFF
--- a/include/riak_kv_index.hrl
+++ b/include/riak_kv_index.hrl
@@ -21,28 +21,32 @@
 %% -------------------------------------------------------------------
 
 %% Index query records
--record(riak_kv_index_v2, {
-          start_key= <<>> :: binary(),
-          filter_field :: binary() | undefined,
-          start_term :: binary() | undefined, %% Note, in a $key query, start_key==start_term
-          end_term :: binary() | undefined, %% Note, in an eq query, start==end
-          return_terms=true :: boolean(), %% Note, should be false for an equals query
-          start_inclusive=true :: boolean(),
-          end_inclusive=true :: boolean(),
-          return_body=false ::boolean() %% Note, only for riak cs bucket folds
-         }).
+-record(riak_kv_index_v2, 
+    {
+        start_key= <<>> :: binary(),
+        filter_field :: binary() | undefined,
+        start_term :: binary() | undefined, %% Note, in a $key query, start_key==start_term
+        end_term :: binary() | undefined, %% Note, in an eq query, start==end
+        return_terms=true :: boolean(), %% Note, should be false for an equals query
+        start_inclusive=true :: boolean(),
+        end_inclusive=true :: boolean(),
+        return_body=false ::boolean() %% Note, only for riak cs bucket folds
+    }
+).
 
--record(riak_kv_index_v3, {
-          start_key= <<>> :: binary(),
-          filter_field :: binary() | undefined,
-          start_term :: integer() | binary() | undefined, %% Note, in a $key query, start_key==start_term
-          end_term :: integer() | binary() | undefined, %% Note, in an eq query, start==end
-          return_terms=true :: boolean(), %% Note, should be false for an equals query
-          start_inclusive=true :: boolean(),
-          end_inclusive=true :: boolean(),
-          return_body=false ::boolean(), %% Note, only for riak cs bucket folds
-          term_regex :: binary() | undefined,
-          max_results :: integer() | undefined
-         }).
+-record(riak_kv_index_v3, 
+    {
+        start_key= <<>> :: binary(),
+        filter_field :: binary() | undefined,
+        start_term :: integer() | binary() | undefined, %% Note, in a $key query, start_key==start_term
+        end_term :: integer() | binary() | undefined, %% Note, in an eq query, start==end
+        return_terms=true :: boolean(), %% Note, should be false for an equals query
+        start_inclusive=true :: boolean(),
+        end_inclusive=true :: boolean(),
+        return_body=false ::boolean(), %% Note, only for riak cs bucket folds
+        term_regex :: binary() | undefined,
+        max_results :: integer() | undefined
+    }
+).
 
 -define(KV_INDEX_Q, #riak_kv_index_v3).

--- a/rebar.config
+++ b/rebar.config
@@ -1,4 +1,4 @@
-{minimum_otp_vsn, "22.0"}.
+{minimum_otp_vsn, "24.0"}.
 
 {cover_enabled, false}.
 {edoc_opts, [{preprocess, true}]}.
@@ -18,7 +18,7 @@
                    "src/riak_kv_backend.erl"
                   ]}.
 
-{plugins, [{rebar3_gpb_plugin, {git, "https://github.com/OpenRiak/rebar3_gpb_plugin", {tag, "openriak-3.4"}}},
+{plugins, [{rebar3_gpb_plugin, {git, "https://github.com/OpenRiak/rebar3_gpb_plugin", {branch, "openriak-3.4"}}},
            {eqc_rebar, {git, "https://github.com/Quviq/eqc-rebar", {branch, "master"}}}]}.
 
 {gpb_opts, [{module_name_suffix, "_pb"},
@@ -31,7 +31,7 @@
                  ]}.
 
 {profiles, [
-    {test, [{deps, [meck]}]},
+    {test, [{deps, [{meck, {git, "https://github.com/OpenRiak/meck.git", {branch, "openriak-3.2"}}}]}]},
     {gha, [{erl_opts, [{d, 'GITHUBEXCLUDE'}]}]}
 ]}.
 

--- a/rebar.config
+++ b/rebar.config
@@ -46,6 +46,7 @@
     {riak_dt, {git, "https://github.com/OpenRiak/riak_dt.git", {branch, "openriak-3.2"}}},
     {riak_api, {git, "https://github.com/OpenRiak/riak_api.git", {branch, "openriak-3.4"}}},
     {hyper, {git, "https://github.com/OpenRiak/hyper", {branch, "openriak-3.2"}}},
+    {leveled, {git, "https://github.com/martinsumner/leveled.git", {branch, "mas-d31-mas.i1433-filterexpression"}}},
     {kv_index_tictactree, {git, "https://github.com/OpenRiak/kv_index_tictactree.git", {branch, "openriak-3.4"}}},
     {rhc, {git, "https://github.com/OpenRiak/riak-erlang-http-client", {branch, "openriak-3.4"}}}
 ]}.

--- a/src/riak_client.erl
+++ b/src/riak_client.erl
@@ -24,6 +24,8 @@
 
 -module(riak_client).
 
+-include_lib("kernel/include/logger.hrl").
+
 -export([new/2]).
 -export([get/3,get/4,get/5]).
 -export([put/2,put/3,put/4,put/5,put/6]).
@@ -37,6 +39,7 @@
 -export([stream_list_buckets/1,stream_list_buckets/2,
          stream_list_buckets/3,stream_list_buckets/4, stream_list_buckets/5]).
 -export([get_index/4,get_index/3]).
+-export([query/2]).
 -export([aae_fold/1, aae_fold/2]).
 -export([ttaaefs_fullsync/1, ttaaefs_fullsync/2, ttaaefs_fullsync/3]).
 -export([hotbackup/4]).
@@ -915,7 +918,7 @@ stream_list_buckets(Filter, Timeout, Client, Type,
     {ok, ReqId}.
 
 
--spec aae_fold(riak_kv_clusteraae_fsm:query_definition())
+-spec aae_fold(riak_kv_aaefold:query_definition())
                     -> {ok, any()}|{error, timeout}|{error, Err :: term()}.
 aae_fold(Query) ->
     aae_fold(Query, riak_client:new(node(), adhoc_aaefold)).
@@ -925,7 +928,7 @@ aae_fold(Query) ->
 %% Run a cluster-wide AAE query - which can either access cached AAE
 %% data across the cluster, or fold over ranges of the AAE store
 %% (which in the case of Leveled can be the native AAE store.
--spec aae_fold(riak_kv_clusteraae_fsm:query_definition(), riak_client())
+-spec aae_fold(riak_kv_aaefold:query_definition(), riak_client())
                     -> {ok, any()}|{error, timeout}|{error, Err :: term()}.
 aae_fold(Query, {?MODULE, [Node, _ClientId]}) ->
     Me = self(),
@@ -1027,12 +1030,25 @@ hotbackup(BackupPath, DefaultNVal, PlanNVal, {?MODULE, [Node, _ClientId]}) ->
     Me = self(),
     ReqId = mk_reqid(),
     TimeOut = ?DEFAULT_FOLD_TIMEOUT,
-    riak_kv_hotbackup_fsm_sup:start_hotbackup_fsm(Node,
-                                                    [{raw, ReqId, Me},
-                                                    [BackupPath,
-                                                        {DefaultNVal, PlanNVal},
-                                                        TimeOut]]),
+    riak_kv_hotbackup_fsm_sup:start_hotbackup_fsm(
+        Node,
+        [{raw, ReqId, Me}, [BackupPath, {DefaultNVal, PlanNVal}, TimeOut]]),
     wait_for_fold_results(ReqId, TimeOut).
+
+
+-spec query(
+    riak_kv_query:complex_query_definition(), riak_client()) ->
+        {ok, [riak_object:key()]} |
+        {ok, [{binary(), riak_object:key()}]} |
+        {ok, #{binary() => non_neg_integer()}} |
+        {error, timeout} |
+        {error, term()}.
+query(Query, {?MODULE, [Node, _ClientId]}) ->
+    TimeoutSecs = riak_kv_query:get_timeout_secs(Query),
+    UpdQuery = riak_kv_query:finalise_request(Query),
+    {ok, Pid, ReqId} = riak_kv_query_sup:start_query_worker(Node, [UpdQuery]),
+    ?LOG_INFO("Query started with worker ~w request ~0p", [Pid, ReqId]),
+    wait_for_reqid(ReqId, TimeoutSecs * 1000).
 
 
 %% @spec get_index(Bucket :: binary(),

--- a/src/riak_kv_aaefold.erl
+++ b/src/riak_kv_aaefold.erl
@@ -1,0 +1,254 @@
+%% -------------------------------------------------------------------
+%%
+%% riak_kv_aaefold: Type definitions for aae_folds
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
+
+-module(riak_kv_aaefold).
+
+%% Building blocks for supported aae fold query definitions
+-type segment_filter() :: list(non_neg_integer()).
+-type tree_size() :: xxsmall|xsmall|small|medium|large|xlarge.
+-type branch_filter() :: list(non_neg_integer()).
+-type key_range() :: {riak_object:key(), riak_object:key()}|all.
+-type bucket() :: riak_object:bucket().
+-type n_val() :: pos_integer().
+-type modified_range() :: {date, non_neg_integer(), non_neg_integer()}.
+    %% dates in modified_range are 32bit integer timestamp of seconds
+    %% since unix epoch
+-type hash_method() :: pre_hash|{rehash, non_neg_integer()}.
+    %% clocks are pre-hashed before storage to reduce CPU load for hash
+    %% comparisons.  However, there may be be hash collisions, and in this case
+    %% it may be periodically required to use an alternate hash.  For this
+    %% {rehash, non_neg_integer()} is used whereby the integer concatenated
+    %% with the hash
+-type change_method() :: {job, pos_integer()}|local|count.
+    %% When reaping tombstones (or erasing keys) the reap/erase can either
+    %% be actioned only by a job-specific riak_kv_reaper/eraser process started
+    %% by this FSM.  Or each fold can send reap/delete requests direct to the
+    %% local node's riak_kv_reaper/riak_kv_eraser to distribute the load across
+    %% the cluster and increase parallelisation of the process.
+    %% The count change_method() will perform no reaps/deletes - but will
+    %% simply count the matching keys - this is cheaper than running
+    %% find_tombs/find_keys to accumulate/sort a large list for counting. 
+
+-type nval_queries() ::
+    % N-val AAE (using cached trees)
+    {merge_root_nval, n_val()}|
+        % Merge the roots of cached Tictac trees for the given n-val to give
+        % a single root for the cluster.  This should be a fast, low-overhead
+        % operation
+    {merge_branch_nval, n_val(), branch_filter()}|
+        % Merge a selection of branches of cached Tictac trees for the given
+        % n-val to give a combined view of those branches across the cluster.
+        % This should be a fast, low-overhead operation
+    {fetch_clocks_nval, n_val(), segment_filter()}|
+    {fetch_clocks_nval, n_val(), segment_filter(), modified_range()}.
+        % Scan over all the keys for a given n_val in the tictac AAE key store
+        % (which for native stores will be the actual key store), skipping 
+        % those blocks of the store not containing keys in the segment filter,
+        % returning a list of keys and clocks for that n_val within the
+        % cluster.  This is a background operation, but will have lower 
+        % overheads than traditional store folds, subject to the size of the
+        % segment filter being small - ideally o(10) or smaller
+        % Variant supported with a modified range, which will be converted into
+        % a fetch_clocks_range
+
+-type range_queries() ::
+    % Range-based AAE (requiring folds over native/parallel AAE key stores)
+    {merge_tree_range, 
+        bucket(),
+        key_range(), 
+        tree_size(),
+        {segments, segment_filter(), tree_size()}|all,
+        modified_range()|all,
+        hash_method()}|
+        % Provide the values for a subset of AAE tree branches for the given
+        % key range.  This will be a background operation, and the cost of
+        % the operation will be in-proportion to the number of keys in the
+        % range, depending on the filter applied
+        %
+        % Different size trees can be requested.  Smaller tree sizes are more
+        % likely to lead to false negative results, but are more efficient
+        % to calculate and have a reduced load on the network
+        % 
+        % A segment_filter() may be passed.  For example, if a tree comparison
+        % has been done between two clusters, it might be preferable to confirm
+        % the differences before fetching clocks. This can be done by
+        % requesting a second tree but placing the mismatched segments into a
+        % segment filter so that the subsequent comparison will be made just on
+        % those segments.  This will reduce the cost of producing the tree by
+        % an order of magnitude.
+        %
+        % A modified_range() may be passed.  This will calculate the tree based
+        % only on the keys which were last modified within the range.  If the
+        % subset of keys above the low date in the range is small relative to
+        % the overall key space in the range - then this will reduce the cost
+        % of producing the tree by an order of magnitude.
+        %
+        % There exists the possibility of a hash collision with the 32-bit
+        % hashes use - i.e. the same key in two stores has different values
+        % that both hash to the same hash.  This is a 1 in 4 billion  chance,
+        % for an occurrence of a replication failure - so the risk of this
+        % being a relevant issue depends on the number of replication failures
+        % expected over the lifetime of a cluster pair.
+        %
+        % Hash collisions are probably not a significant risk in the general
+        % context of eventual consistency, however, there is protection
+        % provided through the ability to set the hash algorithm to be used
+        % when hashing the vector clocks to produce the tree.
+        % See `hash_function/1` for implementation details of the options,
+        % which are either:
+        % - pre_hash (use the default pre-calculated hash)
+        % - {rehash, IV} rehash the vector clock concatenated with an integer
+    {fetch_clocks_range, 
+        bucket(),
+        key_range(), 
+        {segments, segment_filter(), tree_size()} | all,
+        modified_range() | all}|
+        % Return the keys and clocks in the given bucket and key range.
+        % There are two filters that may be applied to the results:
+        % - A segment filter to be used after a tree comparison has shown that
+        % a manageable subset of segments is mismatched.  There is a limit on
+        % the number of segments which may be passed (to ensure the query is
+        % relatively efficient.
+        % - A modified date filter as in merge_tree_range
+        %
+        % Care should be taken when using this feature if TictacAAE is running
+        % in parallel mode with the leveled_so backend (not the leveled_ko)
+        % backend.  If no segment_filter of modified_range is provided, the
+        % whole store will be scanned. The leveled_ko backend should be used
+        % for parallel TictacAAE key stores if range-type folds are to be run.
+        %
+        % Large result sets (e.g. o(100K) keys may cause issues with the size
+        % of the result set.  It is currently an application responsibility to
+        % control the size of the result set by use of the filter options
+        % available.
+        %
+        % TODO - loose_limit()
+        %
+        % The leveled backend supports a max_key_count which could be used to
+        % provide a loose_limit on the results returned.  However, there are
+        % issues with this and segment_ordered backends, as well as extra 
+        % complexity curtailing the results (and signalling the results are
+        % curtailed).  The main downside of large result sets is network over
+        % use.  Perhaps compressing the payload may be a better answer?
+    {repl_keys_range, 
+        bucket(),
+        key_range(), 
+        modified_range() | all,
+        riak_kv_replrtq_src:queue_name()}|
+        % Replicate all the objects in a given key and modified range.  By
+        % sending references to each object to the given queue_name which
+        % should have been pre-configured within the riak_kv_replrtq_src on
+        % each node.
+        % If the queue name is not configured, the work will complete without
+        % any positive outcome.
+        % This is expected to be used when transitioning buckets between
+        % clusters, and also when repairing a cluster from a known outage in
+        % real-time repl (utilising a modified range)
+    {repair_keys_range,
+        bucket(),
+        key_range(),
+        modified_range() | all,
+        all}.
+        % Read repair all keys in the range.  Keys will be read in batches
+        % and then queued for repair
+        % Will default to repairing all keys (i.e. all of those fetched and a
+        % delta is discovered).  Scope to support not_in_coverage later - i.e.
+        % only attempt to read those keys where a primary vnode is not
+        % participating in coverage
+
+-type operations_queries() ::
+    % Operational support functions
+    {find_keys, 
+        bucket(),
+        key_range(),
+        modified_range() | all,
+        {sibling_count, pos_integer()}|{object_size, pos_integer()}}|
+        % Find all the objects in the key range that have more than
+        % the given count of siblings (where {sibling_count, 1} means
+        % find all objects with more than a single, unconflicted
+        % value), or are bigger than the given object size.  This uses
+        % the AAE keystore, and will only discover siblings that have
+        % been generated and stored within a vnode (which should
+        % eventually be all siblings given AAE is enabled and if
+        % allow_mult is true). If finding keys by size, then the size
+        % is the pre-calculated size stored in the aae key store as
+        % metadata.
+        %
+        % The query returns a list of [{Key, SiblingCount}] tuples or 
+        % [{Key, ObjectSize}] tuples depending on the filter requested.  The 
+        % cost of this operation will increase with the size of the range
+        % 
+        % It would be beneficial to use the results of object_stats (or 
+        % knowledge of the application) to ensure that the result size of
+        % this query is reasonably bounded (e.g. don't set too low an object
+        % size).  If only interested in the outcome of recent modifications,
+        % use a modified_range().
+    {object_stats, bucket(), key_range(), modified_range() | all}|
+        % Returns:
+        % - the total count of objects in the key range
+        % - the accumulated total size of all objects in the range
+        % - a list [{Magnitude, ObjectCount}] tuples where Magnitude represents
+        % the order of magnitude of the size of the object (e.g. 1KB is objects 
+        % from 100 bytes to 1KB, 10KB is objects from 1KB to 10KB etc)
+        % - a list of [{SiblingCount, ObjectCount}] tuples where Sibling Count
+        % is the number of siblings the object has.
+        % - sample portion - (n_val * sample_size) / ring_size
+        % e.g.
+        % [{total_count, 1000}, 
+        %   {total_size, 1000000}, 
+        %   {sizes, [{1, 800}, {2, 180}, {3, 20}]}, 
+        %   {siblings, [{1, 1000}]}]
+        %
+        % If only interested in the outcome of recent modifications,
+        % use a modified_range().
+    {find_tombs,
+        bucket(),
+        key_range(), 
+        {segments, segment_filter(), tree_size()} | all,
+        modified_range() | all}|
+        % Find all tombstones in the range that match the criteria, and
+        % return a list of keys and delete_hashes
+    {reap_tombs,
+        bucket(),
+        key_range(),
+        {segments, segment_filter(), tree_size()} | all,
+        modified_range() | all,
+        change_method()}|
+        % Reap all the tombstones in the range using either a job-specific
+        % reaper process, or using the process on each node (local to each
+        % vnode fold).  Should return a count of all the tombstones for
+        % which a reap request was made
+    {erase_keys,
+        bucket(),
+        key_range(),
+        {segments, segment_filter(), tree_size()} | all,
+        modified_range() | all,
+        change_method()}|
+        % Erase keys using a riak_kv_eraser.  This is of specific use when
+        % expiring keys beyond a certain modified date
+    {list_buckets, n_val()}.
+        % List all buckets in the aae store - assuming a given n_val
+
+-type query_definition() ::
+    % Use of these folds depends on the Tictac AAE being enabled in either
+    % native mode, or in parallel mode with key_order being used.  
+    nval_queries() | range_queries() | operations_queries().
+
+-export_type([query_definition/0, hash_method/0]).

--- a/src/riak_kv_backend.erl
+++ b/src/riak_kv_backend.erl
@@ -24,59 +24,150 @@
 
 -export([callback_after/3]).
 
--type fold_buckets_fun() :: fun((binary(), any()) -> any() | no_return()).
--type fold_keys_fun() :: fun((binary(), binary(), any()) -> any() |
-                                                            no_return()).
--type fold_objects_fun() :: fun((binary(), binary(), term(), any()) ->
-                                       any() |
-                                       no_return()).
+-type fold_buckets_fun()
+    :: fun((binary(), any()) -> any() | no_return()).
+-type fold_keys_fun()
+    :: fun((binary(), binary(), any()) -> any() | no_return()).
+-type fold_objects_fun()
+    :: fun((binary(), binary(), term(), any()) -> any() | no_return()).
 
--type index_spec() :: {add | remove, binary(), riak_object:index_value()}.
+-type capability() ::
+    always_v1obj|head|indexes|async_fold|fold_heads|snap_prefold|
+    flush_put|hot_backup|size|leveled|complex_query.
 
--export_type([fold_buckets_fun/0,
-              fold_keys_fun/0,
-              fold_objects_fun/0,
-              fold_opts/0,
-              index_spec/0]).
+-type index_field() :: binary().
+
+-type index_spec() :: {add | remove, index_field(), riak_object:index_value()}.
+
+-export_type(
+    [
+        fold_buckets_fun/0,
+        fold_keys_fun/0,
+        fold_objects_fun/0,
+        fold_opts/0,
+        index_spec/0,
+        fold_acc/0,
+        fold_result/0
+    ]
+).
 
 %% These are just here to make the callback specs more succinct and readable
 -type state() :: term().
 -type fold_acc() :: term().
 -type fold_opts() :: [term()]. %% TODO maybe more specific? [{atom(), term()}]?
--type fold_result() :: {ok, fold_acc()} | {async, fun()} | {error, term()}.
+-type fold_result() ::
+    {ok, fold_acc()} |
+    {async, fun(() -> fold_acc())} |
+    {queue, fun(() -> fold_acc())} |
+    {error, term()}.
 
 -callback api_version() -> {ok, number()}.
 
--callback capabilities(state()) -> {ok, [atom()]}.
--callback capabilities(riak_object:bucket(), state()) -> {ok, [atom()]}.
+-callback capabilities(state()) -> {ok, [capability()]}.
+-callback capabilities(riak_object:bucket(), state()) -> {ok, [capability()]}.
 
--callback start(PartitionIndex :: non_neg_integer(), Config :: [{atom(), term()}]) ->
-    {ok, state()} | {error, term()}.
+-callback
+    start(
+        PartitionIndex :: non_neg_integer(),
+        Config :: [{atom(), term()}]
+    ) -> {ok, state()} | {error, term()}.
 -callback stop(state()) -> ok.
 
--callback get(riak_object:bucket(), riak_object:key(), state()) ->
-    {ok, Value :: term(), state()} |
-    {ok, not_found, state()} |
-    {error, term(), state()}.
--callback put(riak_object:bucket(), riak_object:key(), [index_spec()], Value :: binary(),
-              state()) ->
-    {ok, state()} |
-    {error, term(), state()}.
--callback delete(riak_object:bucket(), riak_object:key(), [index_spec()], state()) ->
-    {ok, state()} |
-    {error, term(), state()}.
+-callback
+    get(
+        riak_object:bucket(),
+        riak_object:key(), state()
+    ) ->
+        {ok, Value :: term(), state()} |
+        {ok, not_found, state()} |
+        {error, term(), state()}.
+-callback
+    put(
+        riak_object:bucket(),
+        riak_object:key(),
+        [index_spec()], Value :: binary(),
+        state()
+    ) -> {ok, state()} | {error, term(), state()}.
+-callback 
+    flush_put(
+        riak_object:bucket(),
+        riak_object:key(),
+        [index_spec()],
+        Value :: binary(),
+        state()
+    ) -> {ok, state()} | {error, term(), state()}.
+-callback
+    delete(
+        riak_object:bucket(),
+        riak_object:key(),
+        [index_spec()],
+        state()
+    ) -> {ok, state()} | {error, term(), state()}.
+
 
 -callback drop(state()) -> {ok, state()} | {error, term(), state()}.
 
--callback fold_buckets(fold_buckets_fun(), fold_acc(), fold_opts(), state()) -> fold_result().
--callback fold_keys(fold_keys_fun(), fold_acc(), fold_opts(), state()) -> fold_result().
--callback fold_objects(fold_objects_fun(), fold_acc(), fold_opts(), state()) -> fold_result().
+-callback
+    fold_buckets(
+        fold_buckets_fun(),
+        fold_acc(),
+        fold_opts(),
+        state()
+    ) -> fold_result().
+-callback
+    fold_keys(
+        fold_keys_fun(),
+        fold_acc(),
+        fold_opts(),
+        state()
+    ) -> fold_result().
+-callback
+    fold_objects(
+        fold_objects_fun(),
+        fold_acc(),
+        fold_opts(),
+        state()
+    ) -> fold_result().
+-callback
+    fold_heads(
+        fold_objects_fun(),
+        fold_acc(),
+        fold_opts(),
+        state()
+    ) -> fold_result().
 
 -callback is_empty(state()) -> boolean() | {error, term()}.
 
 -callback status(state()) -> [{atom(), term()}].
 
+-callback
+    hot_backup(
+        state(),
+        file:name_all()
+    ) -> {queue, fun(() -> any())}|{error, term()}.
+
+-callback
+    data_size(state()) ->
+        undefined |
+        {non_neg_integer(), objects} |
+        {fun(() -> {non_neg_integer(), objects}), dynamic}.
+
+-callback
+    complex_query(
+        fold_keys_fun(),
+        fold_acc(),
+        riak_object:bucket(),
+        riak_kv_query:evaluated_query(),
+        boolean()|binary(),
+        fold_opts(),
+        state()
+    ) -> fold_result().
+
 -callback callback(reference(), Msg :: term(), state()) -> {ok, state()}.
+
+-optional_callbacks(
+    [data_size/1, hot_backup/2, flush_put/5, fold_heads/4, complex_query/7]
+).
 
 %% Queue a callback for the backend after Time ms.
 -spec callback_after(integer(), reference(), term()) -> reference().

--- a/src/riak_kv_backend.erl
+++ b/src/riak_kv_backend.erl
@@ -47,7 +47,8 @@
         fold_opts/0,
         index_spec/0,
         fold_acc/0,
-        fold_result/0
+        fold_result/0,
+        capability/0
     ]
 ).
 
@@ -150,7 +151,8 @@
     data_size(state()) ->
         undefined |
         {non_neg_integer(), objects} |
-        {fun(() -> {non_neg_integer(), objects}), dynamic}.
+        {non_neg_integer(), bytes} |
+        {fun(() -> {non_neg_integer(), objects}|undefined), dynamic}.
 
 -callback
     complex_query(

--- a/src/riak_kv_bitcask_backend.erl
+++ b/src/riak_kv_bitcask_backend.erl
@@ -95,12 +95,13 @@ api_version() ->
     {ok, ?API_VERSION}.
 
 %% @doc Return the capabilities of the backend.
--spec capabilities(state()) -> {ok, [atom()]}.
+-spec capabilities(state()) -> {ok, [riak_kv_backend:capability()]}.
 capabilities(_) ->
     {ok, ?CAPABILITIES}.
 
 %% @doc Return the capabilities of the backend.
--spec capabilities(riak_object:bucket(), state()) -> {ok, [atom()]}.
+-spec capabilities(
+    riak_object:bucket(), state()) -> {ok, [riak_kv_backend:capability()]}.
 capabilities(_, _) ->
     {ok, ?CAPABILITIES}.
 
@@ -278,10 +279,14 @@ delete(Bucket, Key, _IndexSpecs,
     {ok, State}.
 
 %% @doc Fold over all the buckets.
--spec fold_buckets(riak_kv_backend:fold_buckets_fun(),
-                   any(),
-                   [],
-                   state()) -> {ok, any()} | {async, fun()} | {error, term()}.
+-spec fold_buckets(
+    riak_kv_backend:fold_buckets_fun(),
+    any(),
+    [],
+    state()) ->
+        {ok, any()} |
+        {async, fun(() -> riak_kv_backend:fold_acc())} |
+        {error, term()}.
 fold_buckets(FoldBucketsFun, Acc, Opts, #state{opts=BitcaskOpts,
                                                data_dir=DataFile,
                                                ref=Ref,
@@ -321,10 +326,14 @@ fold_buckets(FoldBucketsFun, Acc, Opts, #state{opts=BitcaskOpts,
     end.
 
 %% @doc Fold over all the keys for one or all buckets.
--spec fold_keys(riak_kv_backend:fold_keys_fun(),
-                any(),
-                [{atom(), term()}],
-                state()) -> {ok, term()} | {async, fun()} | {error, term()}.
+-spec fold_keys(
+    riak_kv_backend:fold_keys_fun(),
+    any(),
+    [{atom(), term()}],
+    state()) ->
+        {ok, term()} |
+        {async, fun(() -> riak_kv_backend:fold_acc())} |
+        {error, term()}.
 fold_keys(FoldKeysFun, Acc, Opts, #state{opts=BitcaskOpts,
                                          data_dir=DataFile,
                                          ref=Ref,
@@ -359,10 +368,14 @@ fold_keys(FoldKeysFun, Acc, Opts, #state{opts=BitcaskOpts,
     end.
 
 %% @doc Fold over all the objects for one or all buckets.
--spec fold_objects(riak_kv_backend:fold_objects_fun(),
-                   any(),
-                   [{atom(), term()}],
-                   state()) -> {ok, any()} | {async, fun()} | {error, term()}.
+-spec fold_objects(
+    riak_kv_backend:fold_objects_fun(),
+    any(),
+    [{atom(), term()}],
+    state()) ->
+        {ok, any()} |
+        {async, fun(() -> riak_kv_backend:fold_acc())} |
+        {error, term()}.
 fold_objects(FoldObjectsFun, Acc, Opts, #state{opts=BitcaskOpts,
                                                data_dir=DataFile,
                                                ref=Ref,

--- a/src/riak_kv_clusteraae_fsm.erl
+++ b/src/riak_kv_clusteraae_fsm.erl
@@ -25,7 +25,6 @@
 
 -behaviour(riak_core_coverage_fsm).
 
--include_lib("riak_kv_vnode.hrl").
 -include_lib("riak_pb/include/riak_kv_pb.hrl").
 
 -export([init/2,
@@ -66,241 +65,13 @@
 -type from() :: {atom(), req_id(), pid()}.
 -type req_id() :: non_neg_integer().
 
-%% Building blocks for supported aae fold query definitions
--type segment_filter() :: list(integer()).
--type tree_size() :: leveled_tictac:tree_size().
--type branch_filter() :: list(integer()).
--type key_range() :: {riak_object:key(), riak_object:key()}|all.
--type bucket() :: riak_object:bucket().
--type n_val() :: pos_integer().
--type modified_range() :: {date, non_neg_integer(), non_neg_integer()}.
-    %% dates in modified_range are 32bit integer timestamp of seconds
-    %% since unix epoch
--type hash_method() :: pre_hash|{rehash, non_neg_integer()}.
-    %% clocks are pre-hashed before storage to reduce CPU load for hash
-    %% comparisons.  However, there maye be hash collisions, and in this case
-    %% it may be periodically required to use an alternate hash.  For this
-    %% {rehash, non_neg_integer()} is used whereby the integer concatenated
-    %% with the hash
--type change_method() :: {job, pos_integer()}|local|count.
-    %% When reaping tombstones (or erasing keys) the reap/erase can either
-    %% be actioned only by a job-specific riak_kv_reaper/eraser process started
-    %% by this FSM.  Or each fold can send reap/delete requests direct to the
-    %% local node's riak_kv_reaper/riak_kv_eraser to distribute the load across
-    %% the cluster and increase parallelistaion of the process.
-    %% The count change_method() will perform no reaps/deletes - but will
-    %% simply count the matching keys - this is cheaper than runnning
-    %% find_tombs/find_keys to accumulate/sort a large list for counting. 
 -type query_types() :: 
     merge_root_nval|merge_branch_nval|fetch_clocks_nval|
     merge_tree_range|fetch_clocks_range|repl_keys_range|repair_keys_range|
     find_keys|object_stats|
     find_tombs|reap_tombs|erase_keys|
     list_buckets.
-
--type query_definition() ::
-    % Use of these folds depends on the Tictac AAE being enabled in either
-    % native mode, or in parallel mode with key_order being used.  
-
-    % N-val AAE (using cached trees)
-    {merge_root_nval, n_val()}|
-        % Merge the roots of cached Tictac trees for the given n-val to give
-        % a single root for the cluster.  This should be a fast, low-overhead
-        % operation
-    {merge_branch_nval, n_val(), branch_filter()}|
-        % Merge a selection of branches of cached Tictac trees for the given
-        % n-val to give a combined view of those branches across the cluster.
-        % This should be a fast, low-overhead operation
-    {fetch_clocks_nval, n_val(), segment_filter()}|
-    {fetch_clocks_nval, n_val(), segment_filter(), modified_range()}|
-        % Scan over all the keys for a given n_val in the tictac AAE key store
-        % (which for native stores will be the actual key store), skipping 
-        % those blocks of the store not containing keys in the segment filter,
-        % returning a list of keys and clocks for that n_val within the
-        % cluster.  This is a background operation, but will have lower 
-        % overheads than traditional store folds, subject to the size of the
-        % segment filter being small - ideally o(10) or smaller
-        % Variant supported with a modified range, which will be converted into
-        % a fetch_clocks_range
-
-    % Range-based AAE (requiring folds over native/parallel AAE key stores)
-    {merge_tree_range, 
-        bucket(),
-        key_range(), 
-        tree_size(),
-        {segments, segment_filter(), tree_size()} | all,
-        modified_range() | all,
-        hash_method()}|
-        % Provide the values for a subset of AAE tree branches for the given
-        % key range.  This will be a background operation, and the cost of
-        % the operation will be in-proportion to the number of keys in the
-        % range, depending on the filter applied
-        %
-        % Different size trees can be requested.  Smaller tree sizes are more
-        % likely to lead to false negative results, but are more efficient
-        % to calculate and have a reduced load on the network
-        % 
-        % A segment_filter() may be passed.  For example, if a tree comparison
-        % has been done between two clusters, it might be preferable to confirm
-        % the differences before fetching clocks. This can be done by
-        % requesting a seocnd tree but placing the mismatched segments into a
-        % segment filter so that the subsequent comparison will be made just on
-        % those segments.  This will reduce the cost of producing the tree by
-        % an order of magnitude.
-        %
-        % A modified_range() may be passed.  This will calculate the tree based
-        % only on the keys which were last modified within the range.  If the
-        % subset of keys above the low date in the range is small relative to
-        % the overall key space in the range - then this will reduce the cost
-        % of producing the tree by an order of magnitude.
-        %
-        % There exists the possibility of a hash collision with the 32-bit
-        % hashes use - i.e. the same key in two stores has different values
-        % that both hash to the same hash.  This is a 1 in 4 billion  chance,
-        % for an occurrence of a replication failure - so the risk of this
-        % being a relevant issue depends on the number of replication failures
-        % expected over the lifetime of a cluster pair.
-        %
-        % Hash collisions are probably not a significant risk in the general
-        % context of eventual consistency, however, there is protection
-        % provided through the ability to set the hash algorithm to be used
-        % when hashing the vector clocks to produce the tree.
-        % See `hash_function/1` for implementation details of the options,
-        % which are either:
-        % - pre_hash (use the default pre-calculated hash)
-        % - {rehash, IV} rehash the vector clock concatenated with an integer
-    {fetch_clocks_range, 
-        bucket(),
-        key_range(), 
-        {segments, segment_filter(), tree_size()} | all,
-        modified_range() | all}|
-        % Return the keys and clocks in the given bucket and key range.
-        % There are two filters that may be applied to the results:
-        % - A segment filter to be used after a tree comparison has shown that
-        % a manageable subset of segments is mismatched.  There is a limit on
-        % the number of segments which may be passed (to ensure the query is
-        % relatively efficient.
-        % - A modified date filter as in merge_tree_range
-        %
-        % Care should be taken when using this feature if TictacAAE is running
-        % in parallel mode with the leveled_so backend (not the leveled_ko)
-        % backend.  If no segment_filter of modified_range is provided, the
-        % whole store will be scanned. The leveled_ko backend should be used
-        % for parallel TictacAAE key stores if range-type folds are to be run.
-        %
-        % Large result sets (e.g. o(100K) keys may cause issues with the size
-        % of the result set.  It is currently an application responsibility to
-        % control the size of the result set by use of the filter options
-        % available.
-        %
-        % TODO - loose_limit()
-        %
-        % The leveled backend supports a max_key_count which could be used to
-        % provide a loose_limit on the results returned.  However, there are
-        % issues with this and segment_ordered backends, as well as extra 
-        % complexity curtailing the results (and signalling the results are
-        % curtailed).  The main downside of large result sets is network over
-        % use.  Perhaps compressing the payload may be a better answer?
-    {repl_keys_range, 
-        bucket(),
-        key_range(), 
-        modified_range() | all,
-        riak_kv_replrtq_src:queue_name()}|
-        % Replicate all the objects in a given key and modified range.  By
-        % sending references to each object to the given queue_name which
-        % should have been pre-configured within the riak_kv_replrtq_src on
-        % each node.
-        % If the queue name is not configured, the work will complete without
-        % any positive outcome.
-        % This is expected to be used when transitioning buckets between
-        % clusters, and also when repairing a cluster from a known outage in
-        % real-time repl (utilising a modified range)
-    {repair_keys_range,
-        bucket(),
-        key_range(),
-        modified_range() | all,
-        all}|
-        % Read repair all keys in the range.  Keys will be read in batches
-        % and then queued for repair
-        % Will default to repairing all keys (i.e. all of those fetched and a
-        % delta is discovered).  Scope to support not_in_coverage later - i.e.
-        % only attempt to read those keys where a primary vnode is not
-        % participating in coverage
-
-    % Operational support functions
-    {find_keys, 
-        bucket(),
-        key_range(),
-        modified_range() | all,
-        {sibling_count, pos_integer()}|{object_size, pos_integer()}}|
-        % Find all the objects in the key range that have more than
-        % the given count of siblings (where {sibling_count, 1} means
-        % find all objects with more than a single,unconflicted
-        % value), or are bigger than the given object size.  This uses
-        % the AAE keystore, and will only discover siblings that have
-        % been generated and stored within a vnode (which should
-        % eventually be all siblings given AAE is enabled and if
-        % allow_mult is true). If finding keys by size, then the size
-        % is the pre-calculated size stored in the aae key store as
-        % metadata.
-        %
-        % The query returns a list of [{Key, SiblingCount}] tuples or 
-        % [{Key, ObjectSize}] tuples depending on the filter requested.  The 
-        % cost of this operation will increase with the size of the range
-        % 
-        % It would be beneficial to use the results of object_stats (or 
-        % knowledge of the application) to ensure that the result size of
-        % this query is reasonably bounded (e.g. don't set too low an object
-        % size).  If only interested in the outcom of recent modifications,
-        % use a modified_range().
-
-    {object_stats, bucket(), key_range(), modified_range() | all} |
-        % Returns:
-        % - the total count of objects in the key range
-        % - the accumulated total size of all objects in the range
-        % - a list [{Magnitude, ObjectCount}] tuples where Magnitude represents
-        % the order of magnitude of the size of the object (e.g. 1KB is objects 
-        % from 100 bytes to 1KB, 10KB is objects from 1KB to 10KB etc)
-        % - a list of [{SiblingCount, ObjectCount}] tuples where Sibling Count
-        % is the number of siblings the object has.
-        % - sample portion - (n_val * sample_size) / ring_size
-        % e.g.
-        % [{total_count, 1000}, 
-        %   {total_size, 1000000}, 
-        %   {sizes, [{1, 800}, {2, 180}, {3, 20}]}, 
-        %   {siblings, [{1, 1000}]}]
-        %
-        % If only interested in the outcome of recent modifications,
-        % use a modified_range().
-
-    {find_tombs,
-        bucket(),
-        key_range(), 
-        {segments, segment_filter(), tree_size()} | all,
-        modified_range() | all} |
-        % Find all tombstones in the range that match the criteria, and
-        % return a list of keys and delete_hashes
-    {reap_tombs,
-        bucket(),
-        key_range(),
-        {segments, segment_filter(), tree_size()} | all,
-        modified_range() | all,
-        change_method()} |
-        % Reap all the tombstones in the range using either a job-specific
-        % reaper process, or using the process on each node (local to each
-        % vnode fold).  Should return a count of all the tombstones for
-        % which a reap request was made
-    {erase_keys,
-        bucket(),
-        key_range(),
-        {segments, segment_filter(), tree_size()} | all,
-        modified_range() | all,
-        change_method()} |
-        % Erase keys using a riak_kv_eraser.  This is of specific use when
-        % expiring keys beyond a certain modified date
-    {list_buckets, n_val()}.
-        % List all buckets in the aae store - assuming a given n_val
-
+-type query_definition() :: riak_kv_aaefold:query_definition().
 
 %% NOTE: this is a dialyzer/start war with the weird init needing a
 %% list in second argument thing. Really the second arg of init should
@@ -348,8 +119,6 @@
             riak_kv_vnode_master,
             pos_integer(),
             query_state()}.
-
--export_type([query_definition/0]).
 
 
 -ifdef(TEST).
@@ -768,8 +537,9 @@ encode_key_and_clock(Bucket, Key, Clock) ->
      {<<"key">>, Key},
      {<<"clock">>, base64:encode_to_string(riak_object:encode_vclock(Clock))}].
 
--spec hash_function(hash_method()) ->
-                        pre_hash|fun((vclock:vclock()) -> non_neg_integer()).
+-spec hash_function(
+    riak_kv_aaefold:hash_method()) ->
+        pre_hash|fun((vclock:vclock()) -> non_neg_integer()).
 %% Return a hash function to be applied to the vector clock, to produce the
 %% object hash for the merkle tree.  The pre_hash will use the default
 %% pre-calculated hash of (erlang:phash2(lists:sort(VC)).

--- a/src/riak_kv_eleveldb_backend.erl
+++ b/src/riak_kv_eleveldb_backend.erl
@@ -100,12 +100,13 @@ api_version() ->
     {ok, ?API_VERSION}.
 
 %% @doc Return the capabilities of the backend.
--spec capabilities(state()) -> {ok, [atom()]}.
+-spec capabilities(state()) -> {ok, [riak_kv_backend:capability()]}.
 capabilities(_) ->
     {ok, ?CAPABILITIES}.
 
 %% @doc Return the capabilities of the backend.
--spec capabilities(riak_object:bucket(), state()) -> {ok, [atom()]}.
+-spec capabilities(
+    riak_object:bucket(), state()) -> {ok, [riak_kv_backend:capability()]}.
 capabilities(_, _) ->
     {ok, ?CAPABILITIES}.
 
@@ -365,12 +366,13 @@ delete(Bucket, PrimaryKey, IndexSpecs, #state{ref=Ref,
     end.
 
 %% @doc Fold over all the buckets
--spec fold_buckets(riak_kv_backend:fold_buckets_fun(),
-                   any(),
-                   [],
-                   state()) -> {ok, any()} | {async, fun()}.
-fold_buckets(FoldBucketsFun, Acc, Opts, #state{fold_opts=FoldOpts,
-                                               ref=Ref}) ->
+-spec fold_buckets(
+    riak_kv_backend:fold_buckets_fun(),
+    any(),
+    [],
+    state()) ->
+        {ok, any()} | {async, fun(() -> riak_kv_backend:fold_acc())}.
+fold_buckets(FoldBucketsFun, Acc, Opts, #state{fold_opts=FoldOpts, ref=Ref}) ->
     FoldFun = fold_buckets_fun(FoldBucketsFun),
     FirstKey = to_first_key(undefined),
     FoldOpts1 = [{first_key, FirstKey} | FoldOpts],
@@ -393,10 +395,12 @@ fold_buckets(FoldBucketsFun, Acc, Opts, #state{fold_opts=FoldOpts,
     end.
 
 %% @doc Fold over all the keys for one or all buckets.
--spec fold_keys(riak_kv_backend:fold_keys_fun(),
-                any(),
-                [{atom(), term()}],
-                state()) -> {ok, term()} | {async, fun()}.
+-spec fold_keys(
+    riak_kv_backend:fold_keys_fun(),
+    any(),
+    [{atom(), term()}],
+    state()) ->
+        {ok, term()} | {async, fun(() -> riak_kv_backend:fold_acc())}.
 fold_keys(FoldKeysFun, Acc, Opts, #state{fold_opts=FoldOpts,
                                          fixed_indexes=FixedIdx,
                                          legacy_indexes=WriteLegacyIdx,
@@ -462,8 +466,7 @@ fold_keys(FoldKeysFun, Acc, Opts, #state{fold_opts=FoldOpts,
             {ok, KeyFolder()}
     end.
 
-fold_indexes(FoldIndexFun, Acc, _Opts, #state{fold_opts=FoldOpts,
-                                              ref=Ref}) ->
+fold_indexes(FoldIndexFun, Acc, _Opts, #state{fold_opts=FoldOpts, ref=Ref}) ->
     FirstKey = to_index_key(<<>>, <<>>, <<>>, <<>>),
     FoldOpts1 = [{first_key, FirstKey} | FoldOpts],
     FoldFun = fold_indexes_fun(FoldIndexFun),
@@ -508,12 +511,13 @@ legacy_key_fold(_Ref, _FoldFun, Acc, _FoldOpts, _Query) ->
     Acc.
 
 %% @doc Fold over all the objects for one or all buckets.
--spec fold_objects(riak_kv_backend:fold_objects_fun(),
-                   any(),
-                   [{atom(), term()}],
-                   state()) -> {ok, any()} | {async, fun()}.
-fold_objects(FoldObjectsFun, Acc, Opts, #state{fold_opts=FoldOpts,
-                                               ref=Ref}) ->
+-spec fold_objects(
+    riak_kv_backend:fold_objects_fun(),
+    any(),
+    [{atom(), term()}],
+    state()) ->
+        {ok, any()} | {async, fun(() -> riak_kv_backend:fold_acc())}.
+fold_objects(FoldObjectsFun, Acc, Opts, #state{fold_opts=FoldOpts, ref=Ref}) ->
     %% Figure out how we should limit the fold: by bucket, by
     %% secondary index, or neither (fold across everything.)
     Bucket = lists:keyfind(bucket, 1, Opts),

--- a/src/riak_kv_leveled_backend.erl
+++ b/src/riak_kv_leveled_backend.erl
@@ -1,17 +1,22 @@
-%% ----------------------------------------------------------------------------
-%% This file is provided to you under the Apache License, Version 2.0 (the
-%% "License"); you may not use this file except in compliance with the License.
-%% You may obtain a copy of the License at
+%% -------------------------------------------------------------------
+%%
+%% riak_kv_leveled_backend: Riak leveled backend
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
 %%
 %%   http://www.apache.org/licenses/LICENSE-2.0
 %%
-%% Unless required by applicable law or agreed to in writing, software
-%% distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
-%% WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
-%% License for the specific language governing permissions and limitations
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
 %% under the License.
 %%
-%% ----------------------------------------------------------------------------
+%% -------------------------------------------------------------------
 
 -module(riak_kv_leveled_backend).
 -behavior(riak_kv_backend).
@@ -30,6 +35,7 @@
          fold_buckets/4,
          fold_keys/4,
          fold_objects/4,
+         complex_query/7,
          is_empty/1,
          status/1,
          data_size/1,
@@ -56,16 +62,21 @@
 
 
 -define(RIAK_TAG, o_rkv).
--define(CAPABILITIES, [always_v1obj,
-                        head,
-                        indexes,
-                        async_fold,
-                        fold_heads,
-                        snap_prefold,
-                        flush_put,
-                        hot_backup,
-                        size,
-                        leveled]).
+-define(CAPABILITIES,
+    [
+        always_v1obj,
+        head,
+        indexes,
+        async_fold,
+        fold_heads,
+        snap_prefold,
+        flush_put,
+        hot_backup,
+        size,
+        leveled,
+        complex_query
+    ]
+).
 -define(API_VERSION, 1).
 -define(BUCKET_SDG, <<"MD">>).
 -define(KEY_SDG, <<"SHUDOWN_GUID">>).
@@ -150,46 +161,54 @@ start(Partition, Config) ->
                     {false, true} ->
                         {ok, TS} = file:read_file(FN),
                         LockTS = calendar:now_to_datetime(binary_to_term(TS)),
-                        ?LOG_ERROR("Cannot start in retain mode " ++
-                                        "due to recalc being set on ~w " ++
-                                        "see FN ~s",
-                                        [LockTS, FN]),
+                        ?LOG_ERROR(
+                            "Cannot start in retain mode "
+                            "due to recalc being set on ~w see FN ~s",
+                            [LockTS, FN]
+                        ),
                         {error, invalid_compaction_change};
                     {false, false} ->
                         {ok, retain}
                 end,
 
-            StartOpts = [{root_path, DataDir},
-                            {max_journalsize, MJS},
-                            {max_journalobjectcount, MJC},
-                            {cache_size, BCS},
-                            {max_pencillercachesize, PCS},
-                            {ledger_preloadpagecache_level, PCL},
-                            {sync_strategy, SYS},
-                            {compression_method, CMM},
-                            {compression_point, CMP},
-                            {log_level, LOL},
-                            {max_run_length, MRL},
-                            {database_id, DBid},
-                            {maxrunlength_compactionpercentage, MCP},
-                            {singlefile_compactionpercentage, SCP},
-                            {journalcompaction_scoreonein,
-                                max(1, CRD div CSP)},
-                            {snapshot_timeout_short, TOS},
-                            {snapshot_timeout_long, TOL},
-                            {reload_strategy, [{?RIAK_TAG, ReloadStrategy}]}],
+            StartOpts =
+                [
+                    {root_path, DataDir},
+                    {max_journalsize, MJS},
+                    {max_journalobjectcount, MJC},
+                    {cache_size, BCS},
+                    {max_pencillercachesize, PCS},
+                    {ledger_preloadpagecache_level, PCL},
+                    {sync_strategy, SYS},
+                    {compression_method, CMM},
+                    {compression_point, CMP},
+                    {log_level, LOL},
+                    {max_run_length, MRL},
+                    {database_id, DBid},
+                    {maxrunlength_compactionpercentage, MCP},
+                    {singlefile_compactionpercentage, SCP},
+                    {journalcompaction_scoreonein, max(1, CRD div CSP)},
+                    {snapshot_timeout_short, TOS},
+                    {snapshot_timeout_long, TOL},
+                    {reload_strategy, [{?RIAK_TAG, ReloadStrategy}]}
+                ],
             {ok, Bookie} = leveled_bookie:book_start(StartOpts),
             Ref = make_ref(),
             ValidHours = valid_hours(CLH, CTH),
             schedule_journalcompaction(Ref, Partition, CRD, ValidHours),
-            {ok, #state{bookie=Bookie,
-                        reference=Ref,
-                        partition=Partition,
-                        config=Config,
-                        db_path=DataDir,
-                        compactions_perday = CRD,
-                        valid_hours = ValidHours,
-                        backend_pause_ms = BackendPause}};
+            {
+                ok, 
+                #state{
+                    bookie=Bookie,
+                    reference=Ref,
+                    partition=Partition,
+                    config=Config,
+                    db_path=DataDir,
+                    compactions_perday = CRD,
+                    valid_hours = ValidHours,
+                    backend_pause_ms = BackendPause
+                }
+            };
         {error, Reason} ->
             ?LOG_ERROR("Failed to start leveled backend: ~p\n",
                             [Reason]),
@@ -208,10 +227,10 @@ stop(#state{bookie=Bookie}) ->
 
 
 %% @doc Retrieve an object from the leveled backend as a binary
--spec get(riak_object:bucket(), riak_object:key(), state()) ->
-                 {ok, any(), state()} |
-                 {ok, not_found, state()} |
-                 {error, term(), state()}.
+-spec get(riak_object:bucket(), riak_object:key(),state()) ->
+        {ok, any(), state()} |
+        {ok, not_found, state()} |
+        {error, term(), state()}.
 get(Bucket, Key, #state{bookie=Bookie}=State) ->
     case leveled_bookie:book_get(Bookie, Bucket, Key, ?RIAK_TAG) of
         {ok, Value} ->
@@ -222,9 +241,9 @@ get(Bucket, Key, #state{bookie=Bookie}=State) ->
 
 %% @doc Retrieve an object from the leveled backend as a binary
 -spec head(riak_object:bucket(), riak_object:key(), state()) ->
-                 {ok, any(), state()} |
-                 {ok, not_found, state()} |
-                 {error, term(), state()}.
+        {ok, any(), state()} |
+        {ok, not_found, state()} |
+        {error, term(), state()}.
 head(Bucket, Key, #state{bookie=Bookie}=State) ->
     case leveled_bookie:book_head(Bookie, Bucket, Key, ?RIAK_TAG) of
         {ok, Value} ->
@@ -234,60 +253,56 @@ head(Bucket, Key, #state{bookie=Bookie}=State) ->
     end.
 
 %% @doc Insert an object into the leveled backend.
--spec flush_put(riak_object:bucket(),
-                    riak_object:key(),
-                    [riak_object:index_spec()],
-                    binary(),
-                    state()) ->
-                         {ok, state()} |
-                         {error, term(), state()}.
+-spec flush_put(
+    riak_object:bucket(),
+    riak_object:key(),
+    [riak_object:index_spec()],
+    binary(),
+    state()) -> {ok, state()} | {error, term(), state()}.
 flush_put(Bucket, Key, IndexSpecs, Val, State) ->
     do_put(Bucket, Key, IndexSpecs, Val, true, State).
 
-
--spec put(riak_object:bucket(),
-                    riak_object:key(),
-                    [riak_object:index_spec()],
-                    binary(),
-                    state()) ->
-                         {ok, state()} |
-                         {error, term(), state()}.
+-spec put(
+    riak_object:bucket(),
+    riak_object:key(),
+    [riak_object:index_spec()],
+    binary(),
+    state()) -> {ok, state()} | {error, term(), state()}.
 put(Bucket, Key, IndexSpecs, Val, State) ->
     do_put(Bucket, Key, IndexSpecs, Val, false, State).
 
 
 %% @doc Delete an object from the leveled backend
--spec delete(riak_object:bucket(),
-                riak_object:key(),
-                [riak_object:index_spec()],
-                state()) ->
-                    {ok, state()} |
-                    {error, term(), state()}.
+-spec delete(
+    riak_object:bucket(),
+    riak_object:key(),
+    [riak_object:index_spec()],
+    state()) -> {ok, state()} | {error, term(), state()}.
 delete(Bucket, Key, IndexSpecs, #state{bookie=Bookie}=State) ->
-    case leveled_bookie:book_put(Bookie,
-                                    Bucket, Key, delete, IndexSpecs,
-                                    ?RIAK_TAG) of
+    PutResponse =
+        leveled_bookie:book_put(
+            Bookie, Bucket, Key, delete, IndexSpecs, ?RIAK_TAG),
+    case PutResponse of
         ok ->
             {ok, State};
         pause ->
-            ?LOG_WARNING("Backend ~w paused for ~w ms in response to delete",
-                            [State#state.partition,
-                                State#state.backend_pause_ms]),
+            ?LOG_WARNING(
+                "Backend ~w paused for ~w ms in response to delete",
+                [State#state.partition, State#state.backend_pause_ms]),
             timer:sleep(State#state.backend_pause_ms),                 
             {ok, State}
     end.
 
 %% @doc Fold over all the buckets
--spec fold_buckets(riak_kv_backend:fold_buckets_fun(),
-                   any(),
-                   [],
-                   state()) -> {ok, any()} | {async, fun(() -> any())}.
+-spec fold_buckets(
+    riak_kv_backend:fold_buckets_fun(),
+    any(),
+    [],
+    state()) -> {ok, any()} | {async, fun(() -> any())}.
 fold_buckets(FoldBucketsFun, Acc, Opts, #state{bookie=Bookie}) ->
     {async, Folder} = 
-        leveled_bookie:book_bucketlist(Bookie, 
-                                        ?RIAK_TAG, 
-                                        {FoldBucketsFun, Acc}, 
-                                        all),
+        leveled_bookie:book_bucketlist(
+            Bookie, ?RIAK_TAG, {FoldBucketsFun, Acc}, all),
     case lists:member(async_fold, Opts) of
         true ->
             {async, Folder};
@@ -296,10 +311,11 @@ fold_buckets(FoldBucketsFun, Acc, Opts, #state{bookie=Bookie}) ->
     end.
 
 %% @doc Fold over all the keys for one or all buckets.
--spec fold_keys(riak_kv_backend:fold_keys_fun(),
-                any(),
-                [{atom(), term()}],
-                state()) -> {ok, term()} | {async, fun(() -> any())}.
+-spec fold_keys(
+    riak_kv_backend:fold_keys_fun(),
+    any(),
+    [{atom(), term()}],
+    state()) -> {ok, term()} | {async, fun(() -> any())}.
 fold_keys(FoldKeysFun, Acc, Opts, #state{bookie=Bookie}) ->
     %% Figure out how we should limit the fold: by bucket, by
     %% secondary index, or neither (fold across everything.)
@@ -326,7 +342,8 @@ fold_keys(FoldKeysFun, Acc, Opts, #state{bookie=Bookie}) ->
                     end_term=EndTerm,
                     return_terms=ReturnTerms,
                     start_inclusive=StartInc,
-                    term_regex=TermRegex} = riak_index:upgrade_query(Q),
+                    term_regex=TermRegex
+                } = riak_index:upgrade_query(Q),
 
                 StartKey = 
                     case StartInc of
@@ -395,10 +412,11 @@ fold_keys(FoldKeysFun, Acc, Opts, #state{bookie=Bookie}) ->
 
 
 %% @doc Fold over all the objects for one or all buckets.
--spec fold_objects(riak_kv_backend:fold_objects_fun(),
-                   any(),
-                   [{atom(), term()}],
-                   state()) -> {ok, any()} | {async, fun(() -> any())}.
+-spec fold_objects(
+    riak_kv_backend:fold_objects_fun(),
+    any(),
+    [{atom(), term()}],
+    state()) -> {ok, any()} | {async, fun(() -> any())}.
 fold_objects(FoldObjectsFun, Acc, Opts, #state{bookie=Bookie}) ->
 
     {async, ObjectFolder} =
@@ -431,18 +449,15 @@ fold_objects(FoldObjectsFun, Acc, Opts, #state{bookie=Bookie}) ->
                             {true, _BK} ->
                                 case StndObjFold of   
                                     true ->
-                                        FoldObjectsFun(ObjB,
-                                                        ObjK,
-                                                        Obj, 
-                                                        InnerAcc);
+                                        FoldObjectsFun(
+                                            ObjB, ObjK, Obj, InnerAcc);
                                     false ->
                                         % Assumption here is that if this is 
                                         % not flagged as a standard object fold
                                         % it is using a fold_keys_fun -
                                         % so the object is disguised as a key
-                                        FoldObjectsFun(ObjB,
-                                                        {o, ObjK, Obj}, 
-                                                        InnerAcc)
+                                        FoldObjectsFun(
+                                            ObjB, {o, ObjK, Obj}, InnerAcc)
                                 end;
                             {skip, _BK} ->
                                 InnerAcc;
@@ -467,30 +482,36 @@ fold_objects(FoldObjectsFun, Acc, Opts, #state{bookie=Bookie}) ->
                 % and EndInclusive should be handled by the passed in fold
                 % function (by the riak_index range checker), so null is used
                 % for EndKey
-                leveled_bookie:book_objectfold(Bookie, 
-                                                ?RIAK_TAG,
-                                                FilterBucket, 
-                                                {StartKey, EndKey},
-                                                {SpecialFoldFun, Acc}, 
-                                                false);
+                leveled_bookie:book_objectfold(
+                    Bookie, 
+                    ?RIAK_TAG,
+                    FilterBucket, 
+                    {StartKey, EndKey},
+                    {SpecialFoldFun, Acc}, 
+                    false
+                );
             {false, false} ->
                 % It is expected (but not proven) that sqn_order should be
                 % more efficient than key_order when folding over all objects
-                leveled_bookie:book_objectfold(Bookie, 
-                                                ?RIAK_TAG, 
-                                                {FoldObjectsFun, Acc},
-                                                false, 
-                                                sqn_order);
+                leveled_bookie:book_objectfold(
+                    Bookie, 
+                    ?RIAK_TAG, 
+                    {FoldObjectsFun, Acc},
+                    false, 
+                    sqn_order
+                );
             
             {{bucket, B}, false} ->
                 % The order of this will be key_order and not sqn_order as
                 % defined for fold_objects/4 when not constrained by bucket
-                leveled_bookie:book_objectfold(Bookie, 
-                                                ?RIAK_TAG,
-                                                B, 
-                                                all, 
-                                                {FoldObjectsFun, Acc}, 
-                                                false)
+                leveled_bookie:book_objectfold(
+                    Bookie, 
+                    ?RIAK_TAG,
+                    B, 
+                    all, 
+                    {FoldObjectsFun, Acc}, 
+                    false
+                )
         end,
     case lists:member(async_fold, Opts) of
         true ->
@@ -507,10 +528,11 @@ fold_objects(FoldObjectsFun, Acc, Opts, #state{bookie=Bookie}) ->
 %% expectation that the only the HeadBinary and Size is required, but if the
 %% #r_content.value is required the whole original object can be fetched using
 %% FetchFun(Clone, FetchKey), as long as the fold function has not finished
--spec fold_heads(riak_kv_backend:fold_objects_fun(),
-                   any(),
-                   [{atom(), term()}],
-                   state()) -> {ok, any()} | {async, fun(() -> any())}.
+-spec fold_heads(
+    riak_kv_backend:fold_objects_fun(),
+    any(),
+    [{atom(), term()}],
+    state()) -> {ok, any()} | {async, fun(() -> any())}.
 fold_heads(FoldHeadsFun, Acc, Opts, #state{bookie=Bookie}) ->
     CheckPresence =
         case proplists:get_value(check_presence, Opts) of
@@ -537,31 +559,37 @@ fold_heads(FoldHeadsFun, Acc, Opts, #state{bookie=Bookie}) ->
                 KeyRange = 
                     {IdxQuery#riak_kv_index_v3.start_term,
                         IdxQuery#riak_kv_index_v3.end_term},
-                leveled_bookie:book_headfold(Bookie, 
-                                                ?RIAK_TAG, 
-                                                {range, Bucket, KeyRange},
-                                                {FoldHeadsFun, Acc}, 
-                                                CheckPresence, 
-                                                SnapPreFold, 
-                                                SegmentList);
+                leveled_bookie:book_headfold(
+                    Bookie, 
+                    ?RIAK_TAG, 
+                    {range, Bucket, KeyRange},
+                    {FoldHeadsFun, Acc}, 
+                    CheckPresence, 
+                    SnapPreFold, 
+                    SegmentList
+                );
             false ->
                 case proplists:get_value(bucket, Opts) of
                     undefined ->
-                        leveled_bookie:book_headfold(Bookie, 
-                                                        ?RIAK_TAG, 
-                                                        {FoldHeadsFun, Acc}, 
-                                                        CheckPresence,
-                                                        SnapPreFold,
-                                                        SegmentList);
+                        leveled_bookie:book_headfold(
+                            Bookie, 
+                            ?RIAK_TAG, 
+                            {FoldHeadsFun, Acc}, 
+                            CheckPresence,
+                            SnapPreFold,
+                            SegmentList
+                        );
                     B ->
                         % Equivalent to a $key query, but without the key range
-                        leveled_bookie:book_headfold(Bookie, 
-                                                        ?RIAK_TAG, 
-                                                        {range, B, all},
-                                                        {FoldHeadsFun, Acc}, 
-                                                        CheckPresence, 
-                                                        SnapPreFold, 
-                                                        SegmentList)
+                        leveled_bookie:book_headfold(
+                            Bookie, 
+                            ?RIAK_TAG, 
+                            {range, B, all},
+                            {FoldHeadsFun, Acc}, 
+                            CheckPresence, 
+                            SnapPreFold, 
+                            SegmentList
+                        )
                 end
         end,
 
@@ -574,12 +602,52 @@ fold_heads(FoldHeadsFun, Acc, Opts, #state{bookie=Bookie}) ->
             {ok, HeadFolder()}
     end.
 
+-spec complex_query(
+    riak_kv_backend:fold_keys_fun(),
+    riak_kv_backend:fold_acc(),
+    riak_object:bucket(),
+    riak_kv_query:evaluated_query(),
+    binary() | boolean(),
+    riak_kv_backend:fold_opts(),
+    state()
+) -> riak_kv_backend:fold_result().
+complex_query(
+        FoldTermsFun, InitAcc, Bucket, Query, ReturnTerms, FoldOpts, State) ->
+    {async, FoldFun} =
+        case Query of
+            {QueryComboFun, SubQueries} ->
+                leveled_bookie:book_multiindexfold(
+                    State#state.bookie,
+                    Bucket,
+                    FoldTermsFun,
+                    SubQueries,
+                    QueryComboFun
+                );
+            {IdxField, StartTerm, EndTerm, TermExpression} ->
+                leveled_bookie:book_indexfold(
+                    State#state.bookie,
+                    {Bucket, <<>>},
+                    {FoldTermsFun, InitAcc},
+                    {IdxField, StartTerm, EndTerm},
+                    {ReturnTerms, TermExpression}
+                )
+        end,
+    SnapPreFold = lists:member(snap_prefold, FoldOpts),
+    case {lists:member(async_fold, FoldOpts), SnapPreFold} of
+        {true, true} ->
+            {queue, FoldFun};
+        {true, false} ->
+            {async, FoldFun};
+        _ ->
+            {ok, FoldFun}
+    end.
 
 %% @doc Delete all objects from this leveled backend
--spec drop(state()) -> {ok, state()} | {error, term(), state()}.
-drop(#state{bookie=Bookie, partition=Partition, config=Config}=_State) ->
+-spec drop(state()) -> {ok, state()}.
+drop(#state{bookie=Bookie, partition=Partition, config=Config} = _PrevState) ->
     ok = leveled_bookie:book_destroy(Bookie),
-    start(Partition, Config).
+    {ok, State} = start(Partition, Config),
+    {ok, State}.
 
 %% @doc Returns true if this leveled backend contains any
 %% non-tombstone values; otherwise returns false.
@@ -652,17 +720,21 @@ callback(Ref, compact_journal, State) ->
     _ = spawn(fun() -> log_fragmentation(binary_alloc) end),
     case is_reference(Ref) of
         true ->
-             prompt_journalcompaction(State#state.bookie,
-                                        Ref,
-                                        State#state.partition,
-                                        State#state.compactions_perday,
-                                        State#state.valid_hours),
+            prompt_journalcompaction(
+                State#state.bookie,
+                Ref,
+                State#state.partition,
+                State#state.compactions_perday,
+                State#state.valid_hours
+            ),
              {ok, State}
     end;
 callback(Ref, UnexpectedCallback, State) ->
-    ?LOG_INFO("Ignoring unexpected callback ~w with ref ~w " ++
-                "may be expected if multi-backend",
-                [UnexpectedCallback, Ref]),
+    ?LOG_INFO(
+        "Ignoring unexpected callback ~w with ref ~w "
+        "may be expected if multi-backend",
+        [UnexpectedCallback, Ref]
+    ),
     {ok, State}.
 
 %% ===================================================================
@@ -710,25 +782,37 @@ log_fragmentation(Allocator) ->
             fun(ReconAllocOutputLine, {MBAcc, MCAcc, SBAcc, SCAcc}) ->
                 case ReconAllocOutputLine of
                     {{Allocator, I}, Stats} when I > 0, is_list(Stats) ->
-                        {MBAcc + proplists:get_value(
-                                    mbcs_block_size, Stats, 0),
-                            MCAcc + proplists:get_value(
-                                    mbcs_carriers_size, Stats, 0),
-                            SBAcc + proplists:get_value(
-                                    sbcs_block_size, Stats, 0),
-                            SCAcc + proplists:get_value(
-                                    sbcs_carriers_size, Stats, 0)};
+                        {
+                            MBAcc + get_memstat(mbcs_block_size, Stats),
+                            MCAcc + get_memstat(mbcs_carriers_size, Stats),
+                            SBAcc + get_memstat(sbcs_block_size, Stats),
+                            SCAcc + get_memstat(sbcs_carriers_size, Stats)};
                     _ ->
                         {MBAcc, MCAcc, SBAcc, SCAcc}
                 end
             end,
             {0, 0, 0, 0},
-            recon_alloc:fragmentation(current)),
-    ?LOG_INFO(
-        "Memory for allocator=~p "
-        "mbcs_block_size=~w mbcs_carrier_size=~w "
-        "sbcs_block_size=~w sbcs_carrier_size=~w",
-        [Allocator, MB_BS, MB_CS, SB_BS, SB_CS]).
+            get_fragmentation_stats()
+        ),
+    _ = 
+        ?LOG_INFO(
+            "Memory for allocator=~p "
+            "mbcs_block_size=~w mbcs_carrier_size=~w "
+            "sbcs_block_size=~w sbcs_carrier_size=~w",
+            [Allocator, MB_BS, MB_CS, SB_BS, SB_CS]
+        ),
+    ok.
+
+-spec get_memstat(atom(), list({atom(), non_neg_integer()})) -> non_neg_integer().
+get_memstat(StatType, Stats) ->
+    case proplists:get_value(StatType, Stats, 0) of
+        I when is_integer(I) -> I
+    end.
+
+-spec get_fragmentation_stats() ->
+    list({{atom(), non_neg_integer()}, list({atom(), non_neg_integer()})}).
+get_fragmentation_stats() ->
+    recon_alloc:fragmentation(current).
 
 %% @private
 %% Complete a PUT, with the sync option true/false depending on whether 
@@ -742,16 +826,25 @@ log_fragmentation(Allocator) ->
                          {ok, state()} |
                          {error, term(), state()}.
 do_put(Bucket, Key, IndexSpecs, Val, Sync, #state{bookie=Bookie}=State) ->
-    case leveled_bookie:book_put(Bookie,
-                                    Bucket, Key, Val, IndexSpecs,
-                                    ?RIAK_TAG,
-                                    infinity, Sync) of
+    PutResponse =
+        leveled_bookie:book_put(
+            Bookie,
+            Bucket,
+            Key,
+            Val,
+            IndexSpecs,
+            ?RIAK_TAG,
+            infinity,
+            Sync
+        ),
+    case PutResponse of
         ok ->
             {ok, State};
         pause ->
-            ?LOG_WARNING("Backend ~w paused for ~w ms in response to put",
-                            [State#state.partition,
-                                State#state.backend_pause_ms]),
+            ?LOG_WARNING(
+                "Backend ~w paused for ~w ms in response to put",
+                [State#state.partition, State#state.backend_pause_ms]
+            ),
             timer:sleep(State#state.backend_pause_ms),
             {ok, State}
     end.
@@ -764,8 +857,10 @@ get_data_dir(DataRoot, Partition) ->
         ok ->
             {ok, PartitionDir};
         {error, Reason} ->
-            ?LOG_ERROR("Failed to create leveled dir ~s: ~p",
-                            [PartitionDir, Reason]),
+            ?LOG_ERROR(
+                "Failed to create leveled dir ~s: ~p",
+                [PartitionDir, Reason]
+            ),
             {error, Reason}
     end.
 
@@ -773,14 +868,18 @@ get_data_dir(DataRoot, Partition) ->
 %% Request a callback in the future to check for journal compaction
 -spec schedule_journalcompaction(reference(), integer(), integer(), list(integer())) -> reference().
 schedule_journalcompaction(Ref, PartitionID, PerDay, ValidHours) when is_reference(Ref) ->
-    Interval = leveled_iclerk:schedule_compaction(ValidHours,
-                                                    PerDay,
-                                                    os:timestamp()),
-    ?LOG_INFO("Schedule compaction for interval ~w on partition ~w",
-                    [Interval, PartitionID]),
-    riak_kv_backend:callback_after(Interval * 1000, % callback interval in ms
-                                    Ref,
-                                    compact_journal).
+    Interval =
+        leveled_iclerk:schedule_compaction(ValidHours, PerDay, os:timestamp()),
+    ?LOG_INFO(
+        "Schedule compaction for interval ~w on partition ~w",
+        [Interval, PartitionID]
+    ),
+    riak_kv_backend:callback_after(
+        Interval * 1000, % callback interval in ms
+        Ref,
+        compact_journal
+    
+    ).
 
 %% @private
 %% Do journal compaction if the callback is in a valid time period
@@ -827,33 +926,43 @@ valid_hours(LowHour, HighHour) ->
 
 prop_leveled_backend() ->
     Path = riak_kv_test_util:get_test_dir("leveled-backend"),
-    ?SETUP(fun() ->
-                   application:load(sasl),
-                   application:set_env(sasl,
-                                        sasl_error_logger,
-                                        {file, Path ++ "/riak_kv_leveled_backend_eqc_sasl.log"}),
-                   error_logger:tty(false),
-                   error_logger:logfile({open, Path ++ "/riak_kv_leveled_backend_eqc.log"}),
-                   fun() -> ?assertCmd("rm -rf " ++ Path ++ "/*") end
-           end,
-           backend_eqc:prop_backend(?MODULE,
-                                    false,
-                                    [{data_root, Path},
-                                        {cache_size, 100},
-                                        {penciller_cache_size, 1000},
-                                        {sync_strategy, none},
-                                        {compression_method, native},
-                                        {compression_point, on_receipt},
-                                        {compaction_runs_perday, 1},
-                                        {compaction_low_hour, 1},
-                                        {compaction_top_hour, 23},
-                                        {max_run_length, 2},
-                                        {maxrunlength_compactionpercentage, 70.0},
-                                        {singlefile_compactionpercentage, 50.0},
-                                        {snapshot_timeout_short, 900},
-                                        {snapshot_timeout_long, 3600},
-                                        {log_level, error},
-                                        {journal_objectcount, 100}])).
+    ?SETUP(
+        fun() ->
+            application:load(sasl),
+            application:set_env(
+                sasl,
+                sasl_error_logger,
+                {file, Path ++ "/riak_kv_leveled_backend_eqc_sasl.log"}
+            ),
+            error_logger:tty(false),
+            error_logger:logfile(
+                {open, Path ++ "/riak_kv_leveled_backend_eqc.log"}
+            ),
+            fun() -> ?assertCmd("rm -rf " ++ Path ++ "/*") end
+        end,
+           backend_eqc:prop_backend(
+            ?MODULE,
+            false,
+            [
+                {data_root, Path},
+                {cache_size, 100},
+                {penciller_cache_size, 1000},
+                {sync_strategy, none},
+                {compression_method, native},
+                {compression_point, on_receipt},
+                {compaction_runs_perday, 1},
+                {compaction_low_hour, 1},
+                {compaction_top_hour, 23},
+                {max_run_length, 2},
+                {maxrunlength_compactionpercentage, 70.0},
+                {singlefile_compactionpercentage, 50.0},
+                {snapshot_timeout_short, 900},
+                {snapshot_timeout_long, 3600},
+                {log_level, error},
+                {journal_objectcount, 100}
+            ]
+        )
+    ).
 
 -endif. % EQC
 

--- a/src/riak_kv_leveled_backend.erl
+++ b/src/riak_kv_leveled_backend.erl
@@ -111,12 +111,13 @@ api_version() ->
     {ok, ?API_VERSION}.
 
 %% @doc Return the capabilities of the backend.
--spec capabilities(state()|undefined) -> {ok, [atom()]}.
+-spec capabilities(state()|undefined) -> {ok, [riak_kv_backend:capability()]}.
 capabilities(_) ->
     {ok, ?CAPABILITIES}.
 
 %% @doc Return the capabilities of the backend.
--spec capabilities(riak_object:bucket(), state()) -> {ok, [atom()]}.
+-spec capabilities(
+    riak_object:bucket(), state()) -> {ok, [riak_kv_backend:capability()]}.
 capabilities(_, _) ->
     {ok, ?CAPABILITIES}.
 

--- a/src/riak_kv_memory_backend.erl
+++ b/src/riak_kv_memory_backend.erl
@@ -110,12 +110,13 @@ api_version() ->
     {ok, ?API_VERSION}.
 
 %% @doc Return the capabilities of the backend.
--spec capabilities(state()) -> {ok, [atom()]}.
+-spec capabilities(state()) -> {ok, [riak_kv_backend:capability()]}.
 capabilities(_) ->
     {ok, ?CAPABILITIES}.
 
 %% @doc Return the capabilities of the backend.
--spec capabilities(riak_object:bucket(), state()) -> {ok, [atom()]}.
+-spec capabilities(
+    riak_object:bucket(), state()) -> {ok, [riak_kv_backend:capability()]}.
 capabilities(_, _) ->
     {ok, ?CAPABILITIES}.
 
@@ -309,28 +310,33 @@ fold_buckets(FoldBucketsFun, Acc, Opts, #state{data_ref=DataRef}) ->
     end.
 
 %% @doc Fold over all the keys for one or all buckets.
--spec fold_keys(riak_kv_backend:fold_keys_fun(),
-                any(),
-                [{atom(), term()}],
-                state()) -> {ok, term()} | {async, fun()}.
+-spec fold_keys(
+    riak_kv_backend:fold_keys_fun(),
+    any(),
+    [{atom(), term()}],
+    state()) ->
+        {ok, term()} | {async, fun(() -> riak_kv_backend:fold_acc())}.
 fold_keys(FoldKeysFun, Acc, Opts, State) ->
    fold(fun fold_keys_fun/2, FoldKeysFun, Acc, Opts, State).
 
 %% @doc Fold over all the objects for one or all buckets.
--spec fold_objects(riak_kv_backend:fold_objects_fun(),
-                   any(),
-                   [{atom(), term()}],
-                   state()) -> {ok, any()} | {async, fun()}.
+-spec fold_objects(
+    riak_kv_backend:fold_objects_fun(),
+    any(),
+    [{atom(), term()}],
+    state()) ->
+        {ok, any()} | {async, fun(() -> riak_kv_backend:fold_acc())}.
 fold_objects(FoldObjectsFun, Acc, Opts, State) ->
     fold(fun fold_objects_fun/2, FoldObjectsFun, Acc, Opts, State).
 
 %% @private
 %% @doc generalised fold
--spec fold(function(), riak_kv_backend:fold_objects_fun() |
-           riak_kv_backend:fold_keys_fun(), any(),
-           [{atom(), term()}],
-           state()) ->
-                   {ok, any()} | {async, function()}.
+-spec fold(
+    function(), riak_kv_backend:fold_objects_fun() |
+    riak_kv_backend:fold_keys_fun(), any(),
+    [{atom(), term()}],
+    state()) ->
+        {ok, any()} | {async, fun(() -> riak_kv_backend:fold_acc())}.
 fold(FoldTypeFun, FoldFun0, Acc, Opts, #state{data_ref=DataRef, index_ref=IndexRef}) ->
     %% Figure out how we should limit the fold: by bucket, by
     %% secondary index, or neither (fold across everything.)
@@ -424,14 +430,16 @@ status(#state{data_ref=DataRef,
 
 %% @doc Get the size of the memory backend. Returns a dynamic size
 %%      since new writes may appear in an ets fold
--spec data_size(state()) -> undefined | {function(), dynamic}.
+-spec data_size(
+    state()) -> {fun(() -> {non_neg_integer(), objects}|undefined), dynamic}.
 data_size(#state{data_ref=DataRef}) ->
-    F = fun() ->
-                DataStatus = ets:info(DataRef),
-                case proplists:get_value(size, DataStatus) of
-                    undefined -> undefined;
-                    ObjCount -> {ObjCount, objects}
-                end
+    F = 
+        fun() ->
+            DataStatus = ets:info(DataRef),
+            case proplists:get_value(size, DataStatus) of
+                undefined -> undefined;
+                ObjCount -> {ObjCount, objects}
+            end
         end,
     {F, dynamic}.
 

--- a/src/riak_kv_multi_backend.erl
+++ b/src/riak_kv_multi_backend.erl
@@ -111,7 +111,7 @@ api_version() ->
     {ok, ?API_VERSION}.
 
 %% @doc Return the capabilities of the backend.
--spec capabilities(state()) -> {ok, [atom()]}.
+-spec capabilities(state()) -> {ok, [riak_kv_backend:capability()]}.
 capabilities(State) ->
     %% Expose ?CAPABILITIES plus the intersection of all child
     %% backends. (This backend creates a shim for any backends that
@@ -131,7 +131,8 @@ capabilities(State) ->
     {ok, Capabilities}.
 
 %% @doc Return the capabilities of the backend.
--spec capabilities(riak_object:bucket(), state()) -> {ok, [atom()]}.
+-spec capabilities(
+    riak_object:bucket(), state()) -> {ok, [riak_kv_backend:capability()]}.
 capabilities(Bucket, State) ->
     case Bucket of
         B when is_binary(B) ->
@@ -288,10 +289,14 @@ delete(Bucket, Key, IndexSpecs, State) ->
     end.
 
 %% @doc Fold over all the buckets
--spec fold_buckets(riak_kv_backend:fold_buckets_fun(),
-                   any(),
-                   [{atom(), term()}],
-                   state()) -> {ok, any()} | {async, fun()} | {error, term()}.
+-spec fold_buckets(
+    riak_kv_backend:fold_buckets_fun(),
+    any(),
+    [{atom(), term()}],
+    state()) ->
+        {ok, any()} |
+        {async, fun(() -> riak_kv_backend:fold_acc())} |
+        {error, term()}.
 fold_buckets(FoldBucketsFun, Acc, Opts, State) ->
     fold_all(fold_buckets, FoldBucketsFun, Acc, Opts, State,
              fun default_backend_filter/5).
@@ -302,10 +307,14 @@ fold_indexes(FoldIndexFun, Acc, Opts, State) ->
             fun indexes_filter/5).
 
 %% @doc Fold over all the keys for one or all buckets.
--spec fold_keys(riak_kv_backend:fold_keys_fun(),
-                any(),
-                [{atom(), term()}],
-                state()) -> {ok, any()} | {async, fun()} | {error, term()}.
+-spec fold_keys(
+    riak_kv_backend:fold_keys_fun(),
+    any(),
+    [{atom(), term()}],
+    state()) ->
+        {ok, any()} |
+        {async, fun(() -> riak_kv_backend:fold_acc())} |
+        {error, term()}.
 fold_keys(FoldKeysFun, Acc, Opts, State) ->
     case proplists:get_value(bucket, Opts) of
         undefined ->
@@ -316,10 +325,14 @@ fold_keys(FoldKeysFun, Acc, Opts, State) ->
     end.
 
 %% @doc Fold over all the objects for one or all buckets.
--spec fold_objects(riak_kv_backend:fold_objects_fun(),
-                   any(),
-                   [{atom(), term()}],
-                   state()) -> {ok, any()} | {async, fun()} | {error, term()}.
+-spec fold_objects(
+    riak_kv_backend:fold_objects_fun(),
+    any(),
+    [{atom(), term()}],
+    state()) ->
+        {ok, any()} |
+        {async, fun(() -> riak_kv_backend:fold_acc())} |
+        {error, term()}.
 fold_objects(FoldObjectsFun, Acc, Opts, State) ->
     case proplists:get_value(bucket, Opts) of
         undefined ->

--- a/src/riak_kv_multi_prefix_backend.erl
+++ b/src/riak_kv_multi_prefix_backend.erl
@@ -126,7 +126,7 @@ api_version() ->
     {ok, ?API_VERSION}.
 
 %% @doc Return the capabilities of the backend.
--spec capabilities(state()) -> {ok, [atom()]}.
+-spec capabilities(state()) -> {ok, [riak_kv_backend:capability()]}.
 capabilities(State) ->
     %% Expose ?CAPABILITIES plus the intersection of all child
     %% backends. (This backend creates a shim for any backends that
@@ -143,7 +143,8 @@ capabilities(State) ->
     {ok, Capabilities}.
 
 %% @doc Return the capabilities of the backend.
--spec capabilities(riak_object:bucket(), state()) -> {ok, [atom()]}.
+-spec capabilities(
+    riak_object:bucket(), state()) -> {ok, [riak_kv_backend:capability()]}.
 capabilities(Bucket, State) when is_binary(Bucket) ->
     {_Name, Mod, ModState} = get_backend(Bucket, State),
     Mod:capabilities(ModState);
@@ -325,18 +326,26 @@ delete(Bucket, Key, IndexSpecs, State) ->
     end.
 
 %% @doc Fold over all the buckets
--spec fold_buckets(riak_kv_backend:fold_buckets_fun(),
-                   any(),
-                   [{atom(), term()}],
-                   state()) -> {ok, any()} | {async, fun()} | {error, term()}.
+-spec fold_buckets(
+    riak_kv_backend:fold_buckets_fun(),
+    any(),
+    [{atom(), term()}],
+    state()) ->
+        {ok, any()} |
+        {async, fun(() -> riak_kv_backend:fold_acc())} |
+        {error, term()}.
 fold_buckets(FoldBucketsFun, Acc, Opts, State) ->
     fold_all(fold_buckets, FoldBucketsFun, Acc, Opts, State).
 
 %% @doc Fold over all the keys for one or all buckets.
--spec fold_keys(riak_kv_backend:fold_keys_fun(),
-                any(),
-                [{atom(), term()}],
-                state()) -> {ok, any()} | {async, fun()} | {error, term()}.
+-spec fold_keys(
+    riak_kv_backend:fold_keys_fun(),
+    any(),
+    [{atom(), term()}],
+    state()) ->
+        {ok, any()} |
+        {async, fun(() -> riak_kv_backend:fold_acc())} |
+        {error, term()}.
 fold_keys(FoldKeysFun, Acc, Opts, State) ->
     case proplists:get_value(bucket, Opts) of
         undefined ->
@@ -346,10 +355,14 @@ fold_keys(FoldKeysFun, Acc, Opts, State) ->
     end.
 
 %% @doc Fold over all the objects for one or all buckets.
--spec fold_objects(riak_kv_backend:fold_objects_fun(),
-                   any(),
-                   [{atom(), term()}],
-                   state()) -> {ok, any()} | {async, fun()} | {error, term()}.
+-spec fold_objects(
+    riak_kv_backend:fold_objects_fun(),
+    any(),
+    [{atom(), term()}],
+    state()) ->
+        {ok, any()} |
+        {async, fun(() -> riak_kv_backend:fold_acc())} |
+        {error, term()}.
 fold_objects(FoldObjectsFun, Acc, Opts, State) ->
     case proplists:get_value(bucket, Opts) of
         undefined ->

--- a/src/riak_kv_query.erl
+++ b/src/riak_kv_query.erl
@@ -1,0 +1,909 @@
+%% -------------------------------------------------------------------
+%%
+%% riak_kv_query: Riak module for preparing complex queries
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
+
+-module(riak_kv_query).
+
+-include_lib("kernel/include/logger.hrl").
+
+-export(
+    [
+        new/3,
+        finalise_request/1,
+        get_query_definition/1,
+        get_bucket/1,
+        get_r/1,
+        get_timeout_secs/1,
+        get_accumulator/1,
+        get_querytype/1,
+        get_returnterms/1,
+        get_reqid/1,
+        get_reqid/0,
+        get_clientpid/1,
+        add_aggregation_expression/2,
+        add_accumulation_option/2,
+        add_accumulation_term/2,
+        add_result_provision/2,
+        add_queries/3
+    ]
+).
+
+-type query_type()
+    :: single_query | combo_query.
+-type aggregation_function()
+    :: fun((list(sets:set(riak_object:key()))) -> sets:set(riak_object:key())).
+-type smpl_accumulator()
+    :: keys|key_count|match_count.
+-type term_accumulator()
+    :: term_with_keys|term_with_matchcount|term_with_keycount.
+-type accumulation_option()
+    :: smpl_accumulator()|term_accumulator().
+-type result_provision()
+    :: all|{reference, binary()}.
+-type query_index_name()
+    :: binary().
+-type index_limiter()
+    :: binary(). % Only binary indexes supported
+-type capture_value() :: binary()|integer().
+-type query_filter_fun() ::
+    fun((#{binary() => capture_value()}) -> boolean()).
+-type query_eval_fun() ::
+    fun((binary(), binary()) -> #{binary() => capture_value()}).
+-type query_expression() :: 
+    {query, query_eval_fun(), query_filter_fun()}.
+-type actual_regex() ::
+    {re_pattern, term(), term(), term(), term()}.
+-type term_expression() ::
+    actual_regex()|undefined|query_expression().
+
+-type substitutions() ::
+    #{binary() => binary()|integer()}|#{}.
+-type aggregation_tag() ::
+    pos_integer().
+-type regular_expression() ::
+    string()|undefined.
+-type evaluation_expression() ::
+    string()|undefined.
+-type filter_expression() ::
+    string()|undefined.
+-type query_user_input() ::
+    {
+        aggregation_tag()|undefined,
+        query_index_name(),
+        index_limiter(),
+        index_limiter(),
+        regular_expression(), 
+        evaluation_expression(),
+        filter_expression()
+    }.
+-type evaluated_query() ::
+    {
+        query_index_name(),
+        index_limiter(),
+        index_limiter(),
+        term_expression()
+    }.
+-type query_definition() ::
+    evaluated_query()|
+    {aggregation_function(), list({aggregation_tag(), evaluated_query()})}.
+-type validation_stage() ::
+    aggregation_function|accumulation_option|accumulation_term|
+        result_provision|query_evaluation.
+-type validation_error() ::
+    {error, validation_stage(), binary()}.
+
+-record(riak_kv_query,
+    {
+        bucket
+            :: riak_object:bucket(),
+        type = single_query
+            :: single_query | combo_query,
+        timeout_secs
+            :: pos_integer(),
+        aggregation_expression = single_query
+            :: single_query|aggregation_function(),
+        accumulation_option = keys
+            :: accumulation_option(),
+        accumulation_term = <<"$term">>
+            :: binary(),
+        result_provision = all
+            :: result_provision(),
+        r = 1
+            :: pos_integer(),
+        query
+            :: 
+                undefined |
+                evaluated_query() |
+                list({aggregation_tag(), evaluated_query()}),
+        client_pid
+            :: pid() | undefined,
+        client_reqid
+            :: non_neg_integer() | undefined
+    }
+).
+
+-type complex_query_definition() :: #riak_kv_query{}.
+
+-export_type(
+    [
+        query_type/0,
+        aggregation_function/0,
+        aggregation_tag/0,
+        accumulation_option/0,
+        result_provision/0,
+        query_expression/0,
+        term_expression/0,
+        evaluated_query/0,
+        validation_error/0,
+        query_definition/0,
+        complex_query_definition/0
+    ]
+).
+
+-spec new(riak_object:bucket(), query_type(), pos_integer()) -> complex_query_definition().
+new(Bucket, single_query, Timeout) ->
+    #riak_kv_query{
+        bucket = Bucket,
+        type = single_query,
+        timeout_secs = Timeout,
+        aggregation_expression = single_query
+    };
+new(Bucket, combo_query, Timeout) ->
+    #riak_kv_query{
+        bucket = Bucket,
+        type = combo_query,
+        timeout_secs = Timeout
+    }.
+
+-spec finalise_request(
+    complex_query_definition()) -> complex_query_definition().
+finalise_request(Query) ->
+    ClientPID = self(),
+    ReqID = get_reqid(),
+    Query#riak_kv_query{client_pid = ClientPID, client_reqid = ReqID}.
+
+-spec get_query_definition(
+    complex_query_definition()) -> query_definition().
+get_query_definition(#riak_kv_query{type = Type} = Query)
+        when Type == single_query ->
+    case Query#riak_kv_query.query of
+        EvaluatedQuery when is_tuple(EvaluatedQuery) ->
+            EvaluatedQuery
+    end;
+get_query_definition(
+    #riak_kv_query{type = Type, aggregation_expression = AE} = Query)
+        when Type == combo_query, AE =/= single_query, AE =/= none ->
+    case Query#riak_kv_query.query of
+        EvaluatedQueryList when is_list(EvaluatedQueryList) ->
+            {AE, EvaluatedQueryList}
+    end.
+
+-spec get_bucket(complex_query_definition()) -> riak_object:bucket().
+get_bucket(Query) -> Query#riak_kv_query.bucket.
+
+-spec get_timeout_secs(complex_query_definition()) -> pos_integer().
+get_timeout_secs(Query) -> Query#riak_kv_query.timeout_secs.
+
+-spec get_reqid(complex_query_definition()) -> non_neg_integer().
+get_reqid(#riak_kv_query{client_reqid = ReqID}) when ReqID =/= undefined ->
+    ReqID.
+
+-spec get_clientpid(complex_query_definition()) -> pid().
+get_clientpid(#riak_kv_query{client_pid = PID}) when PID =/= undefined ->
+    PID.
+
+-spec get_accumulator(
+    complex_query_definition()) ->
+        smpl_accumulator()|term_accumulator().
+get_accumulator(#riak_kv_query{accumulation_option= AccO}) ->
+    AccO.
+
+-spec get_returnterms(complex_query_definition()) -> boolean()|binary().
+get_returnterms(Query) ->
+    case get_accumulator(Query) of
+        KeyOnly
+            when 
+                KeyOnly == keys;
+                KeyOnly == key_count;
+                KeyOnly == match_count ->
+            false;
+        _ ->
+            case Query#riak_kv_query.accumulation_term of
+                Term when Term == <<"$term">> ->
+                    true;
+                Term when is_binary(Term) ->
+                    Term
+            end
+    end.
+
+-spec get_r(complex_query_definition()) -> pos_integer().
+get_r(Query) -> Query#riak_kv_query.r.
+
+-spec get_querytype(complex_query_definition()) -> query_type().
+get_querytype(Query) -> Query#riak_kv_query.type.
+
+-spec add_aggregation_expression(
+    complex_query_definition(), string())
+        -> {ok, complex_query_definition()}|validation_error().
+add_aggregation_expression(
+    #riak_kv_query{type = Type} = Query, AggregationString)
+        when Type == combo_query ->
+    case leveled_setop:generate_setop_function(AggregationString) of
+        {error, ParseError} ->
+            ?LOG_WARNING(
+                "Invalid aggregation submitted ~s due to reason ~0p",
+                [AggregationString, ParseError]
+            ),
+            {error, aggregation_function, <<"Invalid function">>};
+        AppFunction ->
+            {
+                ok,
+                Query#riak_kv_query{aggregation_expression = AppFunction}
+            }
+    end;
+add_aggregation_expression(_Query, _AggregationString) ->
+    {
+        error,
+        aggregation_function,
+        <<"Attempt to aggregate single query">>
+    }.
+
+-spec add_accumulation_option(complex_query_definition(), binary()) ->
+    {ok, complex_query_definition()}|validation_error(). 
+add_accumulation_option(
+    #riak_kv_query{type = Type} = Query,
+    AccumulationOption)
+        when
+            Type == combo_query andalso
+            (
+                AccumulationOption == <<"keys">> orelse
+                AccumulationOption == <<"key_count">>
+            ) ->
+    {
+        ok,
+        Query#riak_kv_query{
+            accumulation_option = decode_option(AccumulationOption)}
+        
+    };
+add_accumulation_option(
+    #riak_kv_query{type = Type} = Query,
+    AccumulationOption)
+        when
+            AccumulationOption == <<"keys">>;
+            AccumulationOption == <<"key_count">>;
+            AccumulationOption == <<"match_count">>;
+            AccumulationOption == <<"term_with_keys">>;
+            AccumulationOption == <<"term_with_matchcount">>;
+            AccumulationOption == <<"term_with_keycount">> ->
+    case Type of
+        single_query ->
+            {
+                ok,
+                Query#riak_kv_query{
+                    accumulation_option = decode_option(AccumulationOption)}
+            };
+        combo_query ->
+            {
+                error,
+                accumulation_option,
+                <<"Unsupported option in combination query">>
+            }
+    end;
+add_accumulation_option(_Q, BadOption) when is_binary(BadOption) ->
+    {
+        error,
+        accumulation_option,
+        list_to_binary(
+            io_lib:format(<<"Unrecognised option ~0p">>, [BadOption])
+        )
+    }.
+
+-spec add_accumulation_term(
+    complex_query_definition(), binary()) ->
+        {ok, complex_query_definition()}|validation_error().
+add_accumulation_term(
+    #riak_kv_query{accumulation_option = AccOpt} = Query,
+    AccumulationTerm)
+        when
+            is_binary(AccumulationTerm) andalso
+            (
+                AccOpt == term_with_keys orelse
+                AccOpt == term_with_matchcount orelse
+                AccOpt == term_with_keycount
+            ) ->
+    {
+        ok,
+        Query#riak_kv_query{
+            accumulation_term = AccumulationTerm}
+    };
+add_accumulation_term(
+        #riak_kv_query{accumulation_option = AccOpt}, AccumulationTerm) ->
+    {
+        error,
+        accumulation_term,
+        list_to_binary(
+            io_lib:format(
+                <<"Bad term ~0p with option ~w">>, [AccumulationTerm, AccOpt])
+        )
+        
+    }.
+
+-spec add_result_provision(
+    complex_query_definition(), result_provision())
+        -> {ok, complex_query_definition()}|validation_error().
+add_result_provision(Query, all) ->
+    {ok, Query#riak_kv_query{result_provision = all}};
+add_result_provision(Query, {reference, Ref}) when is_binary(Ref) ->
+    {ok, Query#riak_kv_query{result_provision = {reference, Ref}}};
+add_result_provision(_Query, _BadProvision) ->
+    {
+        error,
+        result_provision,
+        <<"Invalid result provision">>
+    }.
+
+-spec add_queries(
+    complex_query_definition(),
+    list(query_user_input()),
+    substitutions())
+        -> {ok, complex_query_definition()}|validation_error().
+add_queries(Query, Queries, Subs) ->
+    case validate_substitutions(Subs) of
+        ok ->
+            case Query#riak_kv_query.type of
+                single_query when length(Queries) == 1 ->
+                    [SingleQuery] = Queries,
+                    case evaluate_query(single, SingleQuery, Subs) of
+                        {ok, EvaluatedQuery} ->
+                            {
+                                ok,
+                                Query#riak_kv_query{query = EvaluatedQuery}
+                            };
+                        Error ->
+                            Error
+                    end;
+                combo_query when is_list(Queries) ->
+                    case evaluate_combo_queries(Queries, Subs) of
+                        {ok, EvaluatedQueries} ->
+                            {
+                                ok,
+                                Query#riak_kv_query{query = EvaluatedQueries}
+                            };
+                        Error ->
+                            Error
+                    end;
+                _ ->
+                    {
+                        error,
+                        query_evaluation,
+                        <<"Multiple queries passed without aggregation expression">>
+                    }
+            end;
+        Error ->
+            Error
+    end.
+
+-spec validate_substitutions(substitutions()) -> ok|validation_error().
+validate_substitutions(Subs) ->
+    try
+        maps:foreach(
+            fun(K, V) when is_binary(K), is_binary(V); is_integer(V) -> ok end,
+            Subs
+        ),
+        ok
+    catch
+        error:Reason ->
+            ?LOG_WARNING(
+                "Invalid type within substitutions "
+                "failed due to Reason ~0p",
+                [Reason]
+            ),
+            {error, query_evaluation, <<"Invalid type in substitution">>}
+    end.
+
+evaluate_combo_queries(Queries, Subs) ->
+    SortedQueries = lists:ukeysort(1, Queries),
+    case length(SortedQueries) of
+        L when L == length(Queries) ->
+            evaluate_combo_queries(SortedQueries, Subs, []);
+        _UL ->
+            {error, query_evaluation, <<"Incorrect tagging of queries">>}
+    end.
+
+evaluate_combo_queries([], _Subs, Acc) ->
+    {ok, lists:reverse(Acc)};
+evaluate_combo_queries([Q|Rest], Subs, Acc) ->
+    case evaluate_query(multi, Q, Subs) of
+        {AT, {ok, EvaluatedQuery}} ->
+            evaluate_combo_queries(Rest, Subs, [{AT, EvaluatedQuery}|Acc]);
+        {_AT, Error} ->
+            Error
+    end.
+
+evaluate_query(multi, {AT, IN, ST, ET, RE, EE, FE}, Subs) ->
+    case AT of
+        PI when is_integer(PI), PI >= 0 ->
+            {AT, evaluate_query(single, {AT, IN, ST, ET, RE, EE, FE}, Subs)};
+        _ ->
+            {AT,
+                {
+                    error,
+                    query_evaluation,
+                    <<"Untagged query in combination request">>
+                }
+            }
+    end;
+evaluate_query(single, {_AT, IN, ST, ET, RE, EE, FE}, Subs) ->
+    IndexL = string:length(IN),
+    case string:slice(IN, IndexL - 4) of
+        <<"_bin">> ->
+            case {ST, ET} of
+                {ST, ET} when is_binary(ST), is_binary(ET), ST =< ET ->
+                    case {RE, EE, FE} of
+                        {undefined, undefined, undefined} ->
+                            {ok, {IN, ST, ET, undefined}};
+                        {REOnly, undefined, undefined} ->
+                            case re:compile(REOnly) of
+                                {ok, MP} ->
+                                    {ok, {IN, ST, ET, MP}};
+                                {error, ErrSpec} ->
+                                    ?LOG_WARNING(
+                                        "Invalid regular expression "
+                                        "passed to query ~0p",
+                                        [ErrSpec]
+                                    ),
+                                    {
+                                        error,
+                                        query_evaluation,
+                                        <<"Invalid regex">>
+                                    }
+                            end;
+                        {undefined, EE0, FE0}
+                                when FE0 =/= undefined, EE0 =/= undefined ->
+                            case evaluate_expression(EE0, FE0, Subs) of
+                                {query, QEF, QFF} ->
+                                    {ok, {IN, ST, ET, {query, QEF, QFF}}};
+                                Error ->
+                                    Error
+                            end;
+                        {REI, EEI, FEI} ->
+                            ?LOG_WARNING(
+                                "Invalid combination of ~p ~p ~p",
+                                [REI, EEI, FEI]
+                            ),
+                            {
+                                error,
+                                query_evaluation,
+                                <<"Invalid combination of regex/eval/filter">>
+                            }
+                    end;
+                _ ->
+                    {error, query_evaluation, <<"Invalid query range">>}
+            end;
+        _ ->
+            {error, query_evaluation, <<"Invalid index name">>}
+    end.
+
+
+evaluate_expression(EvalExpr, FilterExpr, Subs) ->
+    case leveled_eval:generate_eval_function(EvalExpr, Subs) of
+        EF when is_function(EF, 2) ->
+            case leveled_filter:generate_filter_function(FilterExpr, Subs) of
+                FF when is_function(FF, 1) ->
+                    {query, EF, FF};
+                {error, Error} ->
+                    ?LOG_WARNING(
+                        "Invalid filter function ~s due to reason ~0p",
+                        [FilterExpr, Error]
+                    ),
+                    {error, query_evaluation, <<"Invalid filter function">>}
+            end;
+        {error, Error} ->
+            ?LOG_WARNING(
+                "Invalid eval function ~s due to reason ~0p",
+                [evalExpr, Error]
+            ),
+            {error, query_evaluation, <<"Invalid eval function">>}
+    end.
+
+-spec decode_option(binary()) -> accumulation_option().
+decode_option(<<"keys">>) -> keys;
+decode_option(<<"key_count">>) -> key_count;
+decode_option(<<"match_count">>) -> match_count;
+decode_option(<<"term_with_keys">>) -> term_with_keys;
+decode_option(<<"term_with_matchcount">>) -> term_with_matchcount;
+decode_option(<<"term_with_keycount">>) -> term_with_keycount.
+
+-spec get_reqid() -> non_neg_integer().
+get_reqid() ->
+    erlang:phash2({self(), os:timestamp(), crypto:strong_rand_bytes(2)}).
+
+%%%============================================================================
+%%% Test
+%%%============================================================================
+
+-ifdef(TEST).
+
+-include_lib("eunit/include/eunit.hrl").
+
+new(Bucket, Type) -> new(Bucket, Type, 60).
+
+bad_aggregation_expression_test() ->
+    QS = new({<<"Type">>, <<"Bucket">>}, single_query),
+    ?assertMatch(
+        {error, aggregation_function, <<"Attempt to aggregate single query">>},
+        add_aggregation_expression(QS, <<"$1 UNION $2">>)
+    ),
+    QC = new(<<"Bucket">>, combo_query),
+    ?assertMatch(
+        {error, aggregation_function, <<"Invalid function">>},
+        add_aggregation_expression(QC, <<"$1 UNION S2">>)
+    ),
+    ?assertMatch(
+        {error, aggregation_function, <<"Invalid function">>},
+        add_aggregation_expression(QC, <<"$1 XOR $2">>)
+    ),
+    {ok, UpdQ} = add_aggregation_expression(QC, <<"$1 UNION $2">>),
+    ?assert(is_record(UpdQ, riak_kv_query)).
+
+bad_accumulation_option_test() ->
+    QC = new(<<"Bucket">>, combo_query),
+    ?assertMatch(
+        {
+            error,
+            accumulation_option,
+            <<"Unsupported option in combination query">>
+        },
+        add_accumulation_option(QC, <<"term_with_keys">>)
+    ),
+    QS = new({<<"Type">>, <<"Bucket">>}, single_query),
+    ?assertMatch(
+        {
+            error,
+            accumulation_option,
+            <<"Unrecognised option <<\"trm_with_keys\">>">>
+        },
+        add_accumulation_option(QS, <<"trm_with_keys">>)
+    ),
+    ?assertMatch(
+        {
+            error,
+            accumulation_option,
+            <<"Unrecognised option <<\"trm_with_keys\">>">>
+        },
+        add_accumulation_option(QS, <<"trm_with_keys">>)
+    ).
+
+bad_accumulation_term_test() ->
+    QS = new(<<"bucket">>, single_query),
+    {ok, QS1} = add_accumulation_option(QS, <<"term_with_keycount">>),
+    ?assertMatch(
+        {
+            error,
+            accumulation_term,
+            <<"Bad term 0 with option term_with_keycount">>
+        },
+        add_accumulation_term(QS1, 0)
+    ),
+    {ok, QS2} = add_accumulation_option(QS, <<"key_count">>),
+    ?assertMatch(
+        {
+            error,
+            accumulation_term,
+            <<"Bad term <<\"$term\">> with option key_count">>
+        },
+        add_accumulation_term(QS2, <<"$term">>)
+    ).
+
+bad_result_provision_test() ->
+    QS = new(<<"bucket">>, single_query),
+    ?assertMatch(
+        {
+            error,
+            result_provision,
+            <<"Invalid result provision">>
+        },
+        add_result_provision(QS, 1)
+    ).
+
+bad_singlequery_test() ->
+    QS = new(<<"bucket">>, single_query),
+    EE = <<"delim($term, :delim, ($surname, $dob, $dod, $gns, $pcs))">>,
+    FE = 
+        <<"($dob BETWEEN :low_dob AND :high_dob) "
+            "AND (contains($gns, \"#Willow\") AND contains($pcs, \"#LS\"))">>,
+    Subs =
+        #{
+            <<"delim">> => <<"|">>,
+            <<"low_dob">> => <<"19740301">>,
+            <<"high_dob">> => <<"19761030">>
+        },
+    {ok, R} = 
+        add_queries(
+            QS,
+            [{
+                undefined,
+                <<"index_bin">>,
+                <<"Will">>,
+                <<"Wilm">>,
+                undefined,
+                EE,
+                FE
+            }],
+            Subs
+        ),
+    ?assertMatch(
+        {<<"index_bin">>, <<"Will">>, <<"Wilm">>, _QE},
+        R#riak_kv_query.query
+    ),
+    BadSubs1 = maps:remove(<<"delim">>, Subs),
+    ?assertMatch(
+        {
+            error,
+            query_evaluation,
+            <<"Invalid eval function">>
+        },
+        add_queries(
+            QS,
+            [{
+                undefined,
+                <<"index_bin">>,
+                <<"Will">>,
+                <<"Wilm">>,
+                undefined,
+                EE,
+                FE
+            }],
+            BadSubs1
+        )
+    ),
+    BadSubs2 = maps:put(<<"delim">>, "/", BadSubs1),
+    ?assertMatch(
+        {
+            error,
+            query_evaluation,
+            <<"Invalid type in substitution">>
+        },
+        add_queries(
+            QS,
+            [{
+                undefined,
+                <<"index_bin">>,
+                <<"Will">>,
+                <<"Wilm">>,
+                undefined,
+                EE,
+                FE
+            }],
+            BadSubs2
+        )
+    ),
+    BadSubs3 = maps:remove(<<"low_dob">>, Subs),
+    ?assertMatch(
+        {
+            error,
+            query_evaluation,
+            <<"Invalid filter function">>
+        },
+        add_queries(
+            QS,
+            [{
+                undefined,
+                <<"index_bin">>,
+                <<"Will">>,
+                <<"Wilm">>,
+                undefined,
+                EE,
+                FE
+            }],
+            BadSubs3
+        )
+    ),
+    QC = new(<<"Bucket">>, combo_query),
+    ?assertMatch(
+        {
+            error,
+            query_evaluation,
+            <<"Untagged query in combination request">>
+        },
+        add_queries(
+            QC,
+            [{
+                undefined,
+                <<"index_bin">>,
+                <<"Will">>,
+                <<"Wilm">>,
+                undefined,
+                EE,
+                FE
+            }],
+            Subs
+        )
+    ),
+    BadIndex = <<"index_int">>,
+    ?assertMatch(
+        {
+            error,
+            query_evaluation,
+            <<"Invalid index name">>
+        },
+        add_queries(
+            QS,
+            [{
+                undefined,
+                BadIndex,
+                <<"Will">>,
+                <<"Wilm">>,
+                undefined,
+                EE,
+                FE
+            }],
+            Subs
+        )
+    ),
+    % Revert Start and End term
+    ?assertMatch(
+        {
+            error,
+            query_evaluation,
+            <<"Invalid query range">>
+        },
+        add_queries(
+            QS,
+            [{
+                undefined,
+                <<"index_bin">>,
+                <<"Wilm">>,
+                <<"Will">>,
+                undefined,
+                EE,
+                FE
+            }],
+            Subs
+        )
+    ),
+    % Use integer in range
+    ?assertMatch(
+        {
+            error,
+            query_evaluation,
+            <<"Invalid query range">>
+        },
+        add_queries(
+            QS,
+            [{
+                undefined,
+                <<"index_bin">>,
+                0,
+                <<"Wilm">>,
+                undefined,
+                EE,
+                FE
+            }],
+            Subs
+        )
+    ),
+    % Bad regular expression
+    ?assertMatch(
+        {
+            error,
+            query_evaluation,
+            <<"Invalid regex">>
+        },
+        add_queries(
+            QS,
+            [{
+                undefined,
+                <<"index_bin">>,
+                <<"Will">>,
+                <<"Wilm">>,
+                <<"(?<extract_but_extra_parenthesis>.*))">>,
+                undefined,
+                undefined
+            }],
+            Subs
+        )
+    ),
+    BEE1 = <<"delm($term, :delim, ($surname, $dob, $dod, $gns, $pcs))">>,
+    ?assertMatch(
+        {
+            error,
+            query_evaluation,
+            <<"Invalid eval function">>
+        },
+        add_queries(
+            QS,
+            [{
+                undefined,
+                <<"index_bin">>,
+                <<"Will">>,
+                <<"Wilm">>,
+                undefined,
+                BEE1,
+                FE
+            }],
+            Subs
+        )
+    ),
+    BFE1 = 
+        <<"($dob BETWEEN :low_dob NAND :high_dob) "
+            "AND (contains($gns, \"#Willow\") AND contains($pcs, \"#LS\"))">>,
+    ?assertMatch(
+        {
+            error,
+            query_evaluation,
+            <<"Invalid filter function">>
+        },
+        add_queries(
+            QS,
+            [{
+                undefined,
+                <<"index_bin">>,
+                <<"Will">>,
+                <<"Wilm">>,
+                undefined,
+                EE,
+                BFE1
+            }],
+            Subs
+        )
+    ),
+    % Invalid combination
+    ?assertMatch(
+        {
+            error,
+            query_evaluation,
+            <<"Invalid combination of regex/eval/filter">>
+        },
+        add_queries(
+            QS,
+            [{
+                undefined,
+                <<"index_bin">>,
+                <<"Will">>,
+                <<"Wilm">>,
+                <<"(?<extract>.*)">>,
+                undefined,
+                BFE1
+            }],
+            Subs
+        )
+    ),
+    % Simple query with no expressions allowed
+    {ok, R2} = 
+        add_queries(
+            QS,
+            [{
+                undefined,
+                <<"index_bin">>,
+                <<"Will">>,
+                <<"Wilm">>,
+                undefined,
+                undefined,
+                undefined
+            }],
+            maps:new()
+        ),
+    ?assertMatch(
+        {<<"index_bin">>, <<"Will">>, <<"Wilm">>, _QE2},
+        R2#riak_kv_query.query
+    )
+    .
+
+-endif.

--- a/src/riak_kv_query.erl
+++ b/src/riak_kv_query.erl
@@ -40,7 +40,8 @@
         add_accumulation_option/2,
         add_accumulation_term/2,
         add_result_provision/2,
-        add_queries/3
+        add_queries/3,
+        is_query/1
     ]
 ).
 
@@ -103,7 +104,7 @@
     evaluated_query()|
     {aggregation_function(), list({aggregation_tag(), evaluated_query()})}.
 -type validation_stage() ::
-    aggregation_function|accumulation_option|accumulation_term|
+    aggregation_expression|accumulation_option|accumulation_term|
         result_provision|query_evaluation.
 -type validation_error() ::
     {error, validation_stage(), binary()}.
@@ -152,7 +153,8 @@
         evaluated_query/0,
         validation_error/0,
         query_definition/0,
-        complex_query_definition/0
+        complex_query_definition/0,
+        query_user_input/0
     ]
 ).
 
@@ -239,33 +241,38 @@ get_r(Query) -> Query#riak_kv_query.r.
 get_querytype(Query) -> Query#riak_kv_query.type.
 
 -spec add_aggregation_expression(
-    complex_query_definition(), string())
+    complex_query_definition(), string()|undefined)
         -> {ok, complex_query_definition()}|validation_error().
 add_aggregation_expression(
     #riak_kv_query{type = Type} = Query, AggregationString)
-        when Type == combo_query ->
+        when Type == combo_query, AggregationString =/= undefined ->
     case leveled_setop:generate_setop_function(AggregationString) of
         {error, ParseError} ->
             ?LOG_WARNING(
                 "Invalid aggregation submitted ~s due to reason ~0p",
                 [AggregationString, ParseError]
             ),
-            {error, aggregation_function, <<"Invalid function">>};
+            {error, aggregation_expression, <<"Invalid function">>};
         AppFunction ->
             {
                 ok,
                 Query#riak_kv_query{aggregation_expression = AppFunction}
             }
     end;
+add_aggregation_expression(
+    #riak_kv_query{type = Type} = Query, undefined)
+        when Type == single_query ->
+    {ok, Query};
 add_aggregation_expression(_Query, _AggregationString) ->
     {
         error,
-        aggregation_function,
+        aggregation_expression,
         <<"Attempt to aggregate single query">>
     }.
 
--spec add_accumulation_option(complex_query_definition(), binary()) ->
-    {ok, complex_query_definition()}|validation_error(). 
+-spec add_accumulation_option(
+    complex_query_definition(), binary()|undefined) ->
+        {ok, complex_query_definition()}|validation_error(). 
 add_accumulation_option(
     #riak_kv_query{type = Type} = Query,
     AccumulationOption)
@@ -305,6 +312,8 @@ add_accumulation_option(
                 <<"Unsupported option in combination query">>
             }
     end;
+add_accumulation_option(Query, undefined) ->
+    {ok, Query};
 add_accumulation_option(_Q, BadOption) when is_binary(BadOption) ->
     {
         error,
@@ -315,7 +324,7 @@ add_accumulation_option(_Q, BadOption) when is_binary(BadOption) ->
     }.
 
 -spec add_accumulation_term(
-    complex_query_definition(), binary()) ->
+    complex_query_definition(), binary()|undefined) ->
         {ok, complex_query_definition()}|validation_error().
 add_accumulation_term(
     #riak_kv_query{accumulation_option = AccOpt} = Query,
@@ -332,6 +341,8 @@ add_accumulation_term(
         Query#riak_kv_query{
             accumulation_term = AccumulationTerm}
     };
+add_accumulation_term(Query, undefined) ->
+    {ok, Query};
 add_accumulation_term(
         #riak_kv_query{accumulation_option = AccOpt}, AccumulationTerm) ->
     {
@@ -534,6 +545,9 @@ decode_option(<<"term_with_keycount">>) -> term_with_keycount.
 get_reqid() ->
     erlang:phash2({self(), os:timestamp(), crypto:strong_rand_bytes(2)}).
 
+-spec is_query(complex_query_definition()) -> boolean().
+is_query(Query) -> is_record(Query, riak_kv_query).
+
 %%%============================================================================
 %%% Test
 %%%============================================================================
@@ -547,16 +561,16 @@ new(Bucket, Type) -> new(Bucket, Type, 60).
 bad_aggregation_expression_test() ->
     QS = new({<<"Type">>, <<"Bucket">>}, single_query),
     ?assertMatch(
-        {error, aggregation_function, <<"Attempt to aggregate single query">>},
+        {error, aggregation_expression, <<"Attempt to aggregate single query">>},
         add_aggregation_expression(QS, <<"$1 UNION $2">>)
     ),
     QC = new(<<"Bucket">>, combo_query),
     ?assertMatch(
-        {error, aggregation_function, <<"Invalid function">>},
+        {error, aggregation_expression, <<"Invalid function">>},
         add_aggregation_expression(QC, <<"$1 UNION S2">>)
     ),
     ?assertMatch(
-        {error, aggregation_function, <<"Invalid function">>},
+        {error, aggregation_expression, <<"Invalid function">>},
         add_aggregation_expression(QC, <<"$1 XOR $2">>)
     ),
     {ok, UpdQ} = add_aggregation_expression(QC, <<"$1 UNION $2">>),

--- a/src/riak_kv_query_buffer.erl
+++ b/src/riak_kv_query_buffer.erl
@@ -247,8 +247,10 @@ do_flush(#buffer{type = T} = Buffer) ->
 -spec aggregate(reply_type(), reply_type()|none) -> reply_type().
 aggregate(R, none) ->
     R;
-aggregate({T, KL}, {T, AggKL}) when T == keys; T == term_with_keys ->
+aggregate({T, KL}, {T, AggKL}) when T == keys ->
     {T, lists:merge(KL, AggKL)};
+aggregate({T, KL}, {T, AggKL}) when T == term_with_keys ->
+    {T, lists:umerge(KL, AggKL)};
 aggregate({T, C}, {T, AggC}) when T == match_count; T == key_count ->
     {T, AggC + C};
 aggregate({T, TM}, {T, AggTM})
@@ -261,6 +263,7 @@ reply(#buffer{reply_fun = R}, {T, KL})
     R({T, lists:reverse(KL)});
 reply(#buffer{reply_fun = R}, Result) ->
     R(Result).
+
 
 %%%============================================================================
 %%% Test
@@ -428,6 +431,9 @@ term_with_keys_test() ->
                 lists:seq(101, 200)
             )
         },
+    ok = get_reply(),
+    {L1DupsSubset, _Rest} = lists:split(10, L1),
+    A ! {term_with_keys, L1DupsSubset},
     ok = get_reply(),
     
     A ! stop,

--- a/src/riak_kv_query_buffer.erl
+++ b/src/riak_kv_query_buffer.erl
@@ -1,0 +1,480 @@
+%% -------------------------------------------------------------------
+%%
+%% riak_kv_query_buffer: Riak module for accumulating query results
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
+
+-module(riak_kv_query_buffer).
+
+-export([new/3, add/2, flush/1, aggregate/2]).
+
+-define(VERSION, [{version, 2}]). % to be used in sets
+
+-record(buffer, 
+    {
+        max_size :: pos_integer(),
+        count = 0 :: non_neg_integer(),
+        reply_fun :: reply_fun(),
+        key_acc :: key_accumulator()|none,
+        term_acc :: termkey_accumulator()|none,
+        agg :: buffer_agg()|none,
+        type :: riak_kv_query:accumulation_option()
+    }
+).
+
+-record(key_agg,
+    {
+        set = sets:new(?VERSION) :: keycount_aggregator()
+    }
+).
+
+-record(termcount_agg,
+    {
+        map = maps:new() :: countby_aggregator()   
+    }
+).
+
+-record(termkeycount_agg,
+    {
+        map = maps:new() :: keycountby_aggregator()
+    }
+).
+
+-type key_accumulator()
+    :: list(binary()).
+-type termkey_accumulator()
+    :: list({binary(), binary()}).
+-type keycount_aggregator()
+    :: sets:set(binary()).
+-type countby_aggregator()
+    :: #{binary() => non_neg_integer()}|#{}.
+-type keycountby_aggregator()
+    :: #{binary() => sets:set(binary())}|#{}.
+
+-type reply_type()
+    :: 
+        {keys, key_accumulator()} |
+        {key_count, non_neg_integer()} |
+        {match_count, non_neg_integer()} |
+        {term_with_keys, termkey_accumulator()} |
+        {term_with_matchcount, countby_aggregator()} |
+        {term_with_keycount, countby_aggregator()}.
+-type reply_fun()
+    :: fun((reply_type()|ping) -> ok).
+
+-type buffer_agg()
+    ::
+        #key_agg{} |
+        #termcount_agg{} |
+        #termkeycount_agg{}.
+
+-type buffer() :: #buffer{}.
+
+-export_type([reply_type/0, reply_fun/0, buffer/0]).
+
+-spec new(
+    non_neg_integer(), riak_kv_query:accumulation_option(), reply_fun())
+        -> buffer().
+new(Size, T, ReplyFun) when T == keys ->
+    new_buffer(Size, ReplyFun, keys, none, T);
+new(Size, T, ReplyFun) when T == key_count->
+    new_buffer(Size, ReplyFun, keys, #key_agg{}, T);
+new(Size, T, ReplyFun) when T == match_count ->
+    new_buffer(Size, ReplyFun, none, none, T);
+new(Size, T, ReplyFun) when T == term_with_keys->
+    new_buffer(Size, ReplyFun, terms, none, T);
+new(Size, T, ReplyFun) when T == term_with_matchcount->
+    new_buffer(Size, ReplyFun, terms, #termcount_agg{}, T);
+new(Size, T, ReplyFun) when T == term_with_keycount ->
+    new_buffer(Size, ReplyFun, terms, #termkeycount_agg{}, T).
+
+new_buffer(BufferSize, ReplyFun, AccType, InitAgg, Type) ->
+    {KeyAcc, TermAcc} =
+        case AccType of
+            none -> {none, none};
+            keys -> {[], none};
+            terms -> {none, []}
+        end,
+    #buffer{
+        max_size = BufferSize,
+        reply_fun = ReplyFun,
+        key_acc = KeyAcc,
+        term_acc = TermAcc,
+        agg = InitAgg,
+        type = Type
+    }.
+
+-spec add(binary()|{binary(), binary()}, buffer()) -> buffer().
+add(_Key, #buffer{key_acc = none, term_acc = none, count = C} = Buffer) ->
+    merge(Buffer#buffer{count = C + 1});
+add(Key, #buffer{key_acc = A, count = C} = Buffer)
+        when A =/= none, is_binary(Key) ->
+    merge(Buffer#buffer{key_acc = [Key|A], count = C + 1});
+add({Term, Key}, #buffer{term_acc = A, count = C} = Buffer)
+        when A =/= none, is_binary(Term), is_binary(Key) ->
+    merge(Buffer#buffer{term_acc = [{Term, Key}|A], count = C + 1}).
+
+-spec merge(buffer()) -> buffer().
+merge(#buffer{max_size = MS, count = C} = Buffer)
+        when C < MS ->
+    Buffer;
+merge(#buffer{count = C, key_acc = Acc, type = T} = Buffer)
+        when Acc == none, T == match_count ->
+    reply(Buffer, {T, C}),
+    Buffer#buffer{count = 0};
+merge(#buffer{key_acc = Acc, agg = Agg = Agg, type = T} = Buffer)
+        when Acc =/= none, Agg == none, T == keys ->
+    reply(Buffer, {T, Acc}),
+    Buffer#buffer{key_acc = [], count = 0};
+merge(#buffer{term_acc = Acc, agg = Agg = Agg, type = T} = Buffer)
+        when Acc =/= none, Agg == none, T == term_with_keys ->
+    reply(Buffer, {T, Acc}),
+    Buffer#buffer{term_acc = [], count = 0};
+merge(#buffer{key_acc = Acc, agg = Agg, type = T} = Buffer)
+        when Acc =/= none, is_record(Agg, key_agg), T == key_count  ->
+    reply(Buffer, ping),
+    Buffer#buffer{
+        count = 0,
+        key_acc = [],
+        agg =
+            #key_agg{
+                set = 
+                    sets:union(
+                        sets:from_list(Acc, ?VERSION),
+                        Agg#key_agg.set
+                    )
+            }
+    };
+merge(
+    #buffer{
+        term_acc = Acc, agg = #termcount_agg{map = TCMap}, type = T} = Buffer
+    )
+        when
+            Acc =/= none,
+            is_map(TCMap),
+            T == term_with_matchcount ->
+    reply(Buffer, ping),
+    UpdTCMap =
+        lists:foldl(
+            fun({Term, _Key}, FoldAcc) when is_map(FoldAcc), is_binary(Term) ->
+                maps:update_with(Term, fun(V) -> V + 1 end, 1, FoldAcc)
+            end,
+            TCMap,
+            Acc
+        ),
+    Buffer#buffer{
+        count = 0,
+        term_acc = [],
+        agg = #termcount_agg{map = UpdTCMap}
+    };
+merge(
+    #buffer{
+        term_acc = Acc, agg = #termkeycount_agg{map = TKSMap}, type = T} = Buffer
+    )
+    when
+        Acc =/= none,
+        is_map(TKSMap),
+        T == term_with_keycount ->
+    reply(Buffer, ping),
+    UpdTKSMap =
+        lists:foldl(
+            fun({Term, Key}, FoldAcc)
+                    when is_map(FoldAcc), is_binary(Term), is_binary(Key) ->
+                maps:update_with(
+                    Term, 
+                    fun(S) -> sets:add_element(Key, S) end, 
+                    sets:add_element(Key, sets:new(?VERSION)),
+                    FoldAcc
+                )
+            end,
+            TKSMap,
+            Acc
+        ),
+    Buffer#buffer{
+        count = 0,
+        term_acc = [],
+        agg = #termkeycount_agg{map = UpdTKSMap}
+    }.
+
+-spec flush(buffer()) -> ok.
+flush(#buffer{count = C, type = T} = Buffer) when T == match_count ->
+    reply(Buffer, {T, C});
+flush(#buffer{key_acc = Acc, type = T} = Buffer)
+        when Acc =/= none, T == keys ->
+    reply(Buffer, {T, Acc});
+flush(#buffer{term_acc = Acc, type = T} = Buffer)
+        when Acc =/= none, T == term_with_keys ->
+    reply(Buffer, {T, Acc});
+flush(#buffer{type = T} = Buffer) ->
+    UpdB = merge(Buffer#buffer{count = Buffer#buffer.max_size}),
+    Result = 
+        case {T, UpdB#buffer.agg} of
+            {key_count, Agg} when is_record(Agg, key_agg) ->
+                sets:size(Agg#key_agg.set);
+            {term_with_matchcount, Agg} when is_record(Agg, termcount_agg) ->
+                Agg#termcount_agg.map;
+            {term_with_keycount, Agg} when is_record(Agg, termkeycount_agg) ->
+                maps:map(
+                    fun(_MK, KS) -> sets:size(KS) end,
+                    Agg#termkeycount_agg.map
+                )
+        end,
+    reply(Buffer, {T, Result}).
+
+-spec aggregate(reply_type(), reply_type()|none) -> reply_type().
+aggregate(R, none) ->
+    R;
+aggregate({T, KL}, {T, AggKL}) when T == keys; T == term_with_keys ->
+    {T, lists:merge(KL, AggKL)};
+aggregate({T, C}, {T, AggC}) when T == match_count; T == key_count ->
+    {T, AggC + C};
+aggregate({T, TM}, {T, AggTM})
+        when T == term_with_matchcount; T == term_with_keycount ->
+    {T, maps:merge_with(fun(_K, C, AggC) -> AggC + C end, TM, AggTM)}.
+
+-spec reply(buffer(), reply_type()|ping) -> ok.
+reply(#buffer{reply_fun = R}, {T, KL})
+        when is_list(KL) andalso (T == keys orelse T == term_with_keys) ->
+    R({T, lists:reverse(KL)});
+reply(#buffer{reply_fun = R}, Result) ->
+    R(Result).
+
+%%%============================================================================
+%%% Test
+%%%============================================================================
+
+-ifdef(TEST).
+
+-include_lib("eunit/include/eunit.hrl").
+
+aggregator(ReplyFun, Agg) ->
+    receive
+        ping ->
+            ReplyFun(ok),
+            aggregator(ReplyFun, Agg);
+        stop ->
+            ReplyFun(Agg);
+        check ->
+            ReplyFun(Agg),
+            aggregator(ReplyFun, Agg);
+        Results ->
+            ReplyFun(ok),
+            aggregator(ReplyFun,aggregate(Results, Agg))
+    end.
+
+start_aggregator() ->
+    Me = self(),
+    ReplyFun = fun(M) -> Me ! M end,
+    spawn(fun() -> aggregator(ReplyFun, none) end).
+
+to_key(N) ->
+    list_to_binary(io_lib:format("K~8..0B", [N])).
+
+to_term(N) ->
+    list_to_binary(io_lib:format("T~8..0B", [N])).
+
+keys_test() ->
+    A = start_aggregator(),
+    ReplyFun = fun(M) -> A ! M, receive ok -> ok end end,
+    B = new(64, keys, ReplyFun),
+    UpdB =
+        lists:foldl(
+            fun(I, BAcc) -> add(to_key(I), BAcc) end,
+            B,
+            lists:seq(1, 100) ++ lists:seq(201, 1000)
+        ),
+    ExpectedSize = (900 div 64) * 64,
+    A ! check,
+    {keys, L1} = get_reply(),
+    ?assertMatch(ExpectedSize, length(L1)),
+    ok = flush(UpdB), 
+    A ! check,
+    {keys, L2} = get_reply(),
+    ?assertMatch(900, length(L2)),
+    A ! {keys, lists:map(fun to_key/1, lists:seq(101, 200))},
+    ok = get_reply(),
+    ExpectedList = lists:map(fun to_key/1, lists:seq(1,1000)),
+    A ! stop,
+    {keys, L3} = get_reply(),
+    ?assertMatch([], ExpectedList -- L3),
+    ?assertMatch([], L3 -- ExpectedList),
+    ?assertMatch(L3, lists:sort(L3)).
+
+match_count_test() ->
+    A = start_aggregator(),
+    ReplyFun = fun(M) -> A ! M, receive ok -> ok end end,
+    Type = match_count,
+    B = new(64, Type, ReplyFun),
+    UpdB =
+        lists:foldl(
+            fun(I, BAcc) -> add(to_key(I), BAcc) end,
+            B,
+            lists:seq(1, 100) ++ lists:seq(201, 1000)
+        ),
+    ExpectedSize = (900 div 64) * 64,
+    A ! check,
+    {Type, C1} = get_reply(),
+    ?assertMatch(ExpectedSize, C1),
+    ok = flush(UpdB), 
+    A ! check,
+    {Type, C2} = get_reply(),
+    ?assertMatch(900, C2),
+    A ! {Type, 100},
+    ok = get_reply(),
+    ExpectedCount = 1000,
+    A ! stop,
+    {Type, C3} = get_reply(),
+    ?assertMatch(ExpectedCount, C3).
+
+key_count_basic_test() ->
+    A = start_aggregator(),
+    ReplyFun = fun(M) -> A ! M, receive ok -> ok end end,
+    Type = key_count,
+    B = new(64, Type, ReplyFun),
+    UpdB =
+        lists:foldl(
+            fun(I, BAcc) -> add(to_key(I), BAcc) end,
+            B,
+            lists:seq(1, 100) ++ lists:seq(201, 1000)
+        ),
+    A ! check,
+    none = get_reply(),
+    ok = flush(UpdB), 
+    A ! check,
+    {Type, C2} = get_reply(),
+    ?assertMatch(900, C2),
+    A ! {Type, 100},
+    ok = get_reply(),
+    ExpectedCount = 1000,
+    A ! stop,
+    {Type, C3} = get_reply(),
+    ?assertMatch(ExpectedCount, C3).
+
+match_count_dup_test() ->
+    duplicate_count_tester(match_count, 1100).
+
+key_count_dup_test() ->
+    duplicate_count_tester(key_count, 1000).
+
+duplicate_count_tester(Type, ExpectedCount) ->
+    A = start_aggregator(),
+    ReplyFun = fun(M) -> A ! M, receive ok -> ok end end,
+    B = new(64, Type, ReplyFun),
+    UpdB =
+        lists:foldl(
+            fun(I, BAcc) -> add(to_key(I), BAcc) end,
+            B,
+            lists:seq(1, 1000)
+        ),
+    UpdWithDupB =
+        lists:foldl(
+            fun(I, BAcc) -> add(to_key(I + 10), BAcc) end,
+            UpdB,
+            lists:seq(1, 100)
+        ),
+    ok = flush(UpdWithDupB),
+    A ! stop,
+    {Type, C1} = get_reply(),
+    ?assertMatch(ExpectedCount, C1).
+
+term_with_keys_test() ->
+    A = start_aggregator(),
+    ReplyFun = fun(M) -> A ! M, receive ok -> ok end end,
+    B = new(64, term_with_keys, ReplyFun),
+    UpdB =
+        lists:foldl(
+            fun(I, BAcc) ->
+                add({to_term(I), to_key(rand:uniform(1000))}, BAcc)
+            end,
+            B,
+            lists:seq(1, 100) ++ lists:seq(201, 1000)
+        ),
+    ExpectedSize = (900 div 64) * 64,
+    A ! check,
+    {term_with_keys, L1} = get_reply(),
+    ?assertMatch(ExpectedSize, length(L1)),
+    ok = flush(UpdB), 
+    A ! check,
+    {term_with_keys, L2} = get_reply(),
+    ?assertMatch(900, length(L2)),
+    A ! 
+        {
+            term_with_keys,
+            lists:map(
+                fun(I) -> {to_term(I), to_key(rand:uniform(1000))} end,
+                lists:seq(101, 200)
+            )
+        },
+    ok = get_reply(),
+    
+    A ! stop,
+    {term_with_keys, L3} = get_reply(),
+    L4 =
+        lists:filter(
+            fun({T, K}) -> is_binary(T) andalso is_binary(K) end,
+            L3
+        ),
+    ?assertMatch(1000, length(L3)),
+    ?assertMatch(1000, length(L4)),
+    ?assertMatch(L3, lists:sort(L3)).
+
+term_with_keycount_test() ->
+    duplicate_term_count_tester(term_with_keycount, 10, 11).
+
+term_with_matchcount_test() ->
+    duplicate_term_count_tester(term_with_matchcount, 90, 91).
+
+duplicate_term_count_tester(Type, C1, C2) ->
+    A = start_aggregator(),
+    ReplyFun = fun(M) -> A ! M, receive ok -> ok end end,
+    B = new(64, Type, ReplyFun),
+    UpdB =
+        lists:foldl(
+            fun(I, BAcc) ->
+                add({to_term(I rem 10), to_key(I rem 100)}, BAcc)
+            end,
+            B,
+            lists:seq(1, 100) ++ lists:seq(201, 1000)
+        ),
+    ok = flush(UpdB), 
+    A ! check,
+    {Type, KC2} = get_reply(),
+    ExpMap2 = lists:map(fun(I) -> {to_term(I), C1} end, lists:seq(0, 9)),
+    ?assertMatch(10, maps:size(KC2)),
+    ?assertMatch(C1, maps:get(to_term(0), KC2)),
+    ?assertMatch(C1, maps:get(to_term(1), KC2)),
+    ?assertMatch(ExpMap2, lists:sort(maps:to_list(KC2))),
+    A ! 
+        {
+            Type,
+            maps:from_list(
+                lists:map(
+                    fun(I) -> {to_term(I), 1} end,
+                    lists:seq(0, 9)
+                )
+            )
+        },
+    ok = get_reply(),
+    A ! stop,
+    {Type, KC3} = get_reply(),
+    ExpMap3 = lists:map(fun(I) -> {to_term(I), C2} end, lists:seq(0, 9)),
+    ?assertMatch(ExpMap3, lists:sort(maps:to_list(KC3))).
+
+get_reply() ->
+    receive Reply -> Reply end.
+
+-endif.

--- a/src/riak_kv_query_buffer.erl
+++ b/src/riak_kv_query_buffer.erl
@@ -32,7 +32,8 @@
         key_acc :: key_accumulator()|none,
         term_acc :: termkey_accumulator()|none,
         agg :: buffer_agg()|none,
-        type :: riak_kv_query:accumulation_option()
+        type :: riak_kv_query:accumulation_option(),
+        start_time = os:system_time(microsecond) :: pos_integer()
     }
 ).
 
@@ -210,16 +211,24 @@ merge(
         agg = #termkeycount_agg{map = UpdTKSMap}
     }.
 
+
+
 -spec flush(buffer()) -> ok.
-flush(#buffer{count = C, type = T} = Buffer) when T == match_count ->
+flush(Buffer) ->
+    do_flush(Buffer),
+    Duration = os:system_time(microsecond) - Buffer#buffer.start_time,
+    ok = riak_kv_stat:update({query_vnode_time, Duration}),
+    ok.
+    
+do_flush(#buffer{count = C, type = T} = Buffer) when T == match_count ->
     reply(Buffer, {T, C});
-flush(#buffer{key_acc = Acc, type = T} = Buffer)
+do_flush(#buffer{key_acc = Acc, type = T} = Buffer)
         when Acc =/= none, T == keys ->
     reply(Buffer, {T, Acc});
-flush(#buffer{term_acc = Acc, type = T} = Buffer)
+do_flush(#buffer{term_acc = Acc, type = T} = Buffer)
         when Acc =/= none, T == term_with_keys ->
     reply(Buffer, {T, Acc});
-flush(#buffer{type = T} = Buffer) ->
+do_flush(#buffer{type = T} = Buffer) ->
     UpdB = merge(Buffer#buffer{count = Buffer#buffer.max_size}),
     Result = 
         case {T, UpdB#buffer.agg} of

--- a/src/riak_kv_query_buffer.erl
+++ b/src/riak_kv_query_buffer.erl
@@ -139,11 +139,11 @@ merge(#buffer{count = C, key_acc = Acc, type = T} = Buffer)
     Buffer#buffer{count = 0};
 merge(#buffer{key_acc = Acc, agg = Agg = Agg, type = T} = Buffer)
         when Acc =/= none, Agg == none, T == keys ->
-    reply(Buffer, {T, Acc}),
+    reply(Buffer, {T, lists:usort(Acc)}),
     Buffer#buffer{key_acc = [], count = 0};
 merge(#buffer{term_acc = Acc, agg = Agg = Agg, type = T} = Buffer)
         when Acc =/= none, Agg == none, T == term_with_keys ->
-    reply(Buffer, {T, Acc}),
+    reply(Buffer, {T, lists:usort(Acc)}),
     Buffer#buffer{term_acc = [], count = 0};
 merge(#buffer{key_acc = Acc, agg = Agg, type = T} = Buffer)
         when Acc =/= none, is_record(Agg, key_agg), T == key_count  ->
@@ -224,10 +224,10 @@ do_flush(#buffer{count = C, type = T} = Buffer) when T == match_count ->
     reply(Buffer, {T, C});
 do_flush(#buffer{key_acc = Acc, type = T} = Buffer)
         when Acc =/= none, T == keys ->
-    reply(Buffer, {T, Acc});
+    reply(Buffer, {T, lists:usort(Acc)});
 do_flush(#buffer{term_acc = Acc, type = T} = Buffer)
         when Acc =/= none, T == term_with_keys ->
-    reply(Buffer, {T, Acc});
+    reply(Buffer, {T, lists:usort(Acc)});
 do_flush(#buffer{type = T} = Buffer) ->
     UpdB = merge(Buffer#buffer{count = Buffer#buffer.max_size}),
     Result = 
@@ -247,9 +247,7 @@ do_flush(#buffer{type = T} = Buffer) ->
 -spec aggregate(reply_type(), reply_type()|none) -> reply_type().
 aggregate(R, none) ->
     R;
-aggregate({T, KL}, {T, AggKL}) when T == keys ->
-    {T, lists:merge(KL, AggKL)};
-aggregate({T, KL}, {T, AggKL}) when T == term_with_keys ->
+aggregate({T, KL}, {T, AggKL}) when T == keys; T == term_with_keys ->
     {T, lists:umerge(KL, AggKL)};
 aggregate({T, C}, {T, AggC}) when T == match_count; T == key_count ->
     {T, AggC + C};
@@ -259,8 +257,8 @@ aggregate({T, TM}, {T, AggTM})
 
 -spec reply(buffer(), reply_type()|ping) -> ok.
 reply(#buffer{reply_fun = R}, {T, KL})
-        when is_list(KL) andalso (T == keys orelse T == term_with_keys) ->
-    R({T, lists:reverse(KL)});
+        when is_list(KL), (T == keys orelse T == term_with_keys) ->
+    R({T, KL});
 reply(#buffer{reply_fun = R}, Result) ->
     R(Result).
 
@@ -307,7 +305,9 @@ keys_test() ->
         lists:foldl(
             fun(I, BAcc) -> add(to_key(I), BAcc) end,
             B,
-            lists:seq(1, 100) ++ lists:seq(201, 1000)
+            lists:reverse(lists:seq(201, 300)) ++ 
+                lists:seq(301, 1000) ++
+                lists:seq(1, 100)
         ),
     ExpectedSize = (900 div 64) * 64,
     A ! check,
@@ -413,7 +413,9 @@ term_with_keys_test() ->
                 add({to_term(I), to_key(rand:uniform(1000))}, BAcc)
             end,
             B,
-            lists:seq(1, 100) ++ lists:seq(201, 1000)
+            lists:reverse(lists:seq(201, 300)) ++ 
+                lists:seq(301, 1000) ++
+                lists:seq(1, 100)
         ),
     ExpectedSize = (900 div 64) * 64,
     A ! check,

--- a/src/riak_kv_query_server.erl
+++ b/src/riak_kv_query_server.erl
@@ -41,7 +41,7 @@
 %% refactored in line with this - and this may involve re-introducing a
 %% common behaviour.
 
--module(riak_kv_query_worker).
+-module(riak_kv_query_server).
 
 -behaviour(gen_server).
 
@@ -493,7 +493,7 @@ update_timings(Timings) ->
 -spec log_timings(timings(), riak_object:bucket(), non_neg_integer()) -> ok.
 log_timings(Timings, Bucket, ResultCount) ->
     Duration = timer:now_diff(os:timestamp(), Timings#timings.start_time),
-    ok = riak_kv_stat:update({index_fsm_time, Duration, ResultCount}),
+    ok = riak_kv_stat:update({query_node_time, Duration, ResultCount}),
     log_timings(Timings,
                 Bucket,
                 ResultCount,

--- a/src/riak_kv_query_server.erl
+++ b/src/riak_kv_query_server.erl
@@ -139,6 +139,8 @@
 -type vnode_id() :: non_neg_integer().
 -type vnode_monitor() :: #{vnode_id() => non_neg_integer()}|#{}.
 
+-export_type([results/0]).
+
 
 %%%============================================================================
 %%% API
@@ -258,7 +260,6 @@ handle_info(
         {{ReqID, Vnode}, {From, _B, {keys, Results}}}, 
         #state{req_id = ReqID} = State) ->
     riak_kv_vnode:ack_keys(From),
-    ?LOG_INFO("Received result size ~w ack'd to ~0p", [length(Results), From]),
     {keys, UpdResults} =
         riak_kv_query_buffer:aggregate(
             {keys, Results},
@@ -387,7 +388,6 @@ handle_info(
                         {RM, lists:sum(maps:values(RM))}
                 end,
             {raw, ClientReqID, ClientPid} = State#state.from,
-            ?LOG_INFO("Returning response ~0p", [Results]),
             ClientPid ! {ClientReqID, Results},
             log_timings(
                 UpdTimings,
@@ -396,10 +396,6 @@ handle_info(
             ),
             {stop, normal, State};
         _ ->
-            ?LOG_INFO(
-                "Query done for ~w remainining ~w",
-                [Vnode, sets:size(UpdCoverageVnodes)]
-            ),
             {
                 noreply,
                 State#state{

--- a/src/riak_kv_query_sup.erl
+++ b/src/riak_kv_query_sup.erl
@@ -1,0 +1,59 @@
+%% -------------------------------------------------------------------
+%%
+%% riak_kv_query_fsm_sup: supervise the riak_kv query state machines.
+%%
+%% Copyright (c) 2007-2011 Basho Technologies, Inc.  All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
+
+%% @doc supervise the riak_kv query state machines used to
+%% process complex secondary index queries.
+
+-module(riak_kv_query_sup).
+
+-behaviour(supervisor).
+
+-export([start_query_worker/2]).
+-export([start_link/0]).
+-export([init/1]).
+
+start_query_worker(Node, Args) ->
+    case supervisor:start_child({?MODULE, Node}, Args) of
+        {ok, Pid} ->
+            ok = riak_kv_stat:update({query_create, Pid}),
+            {ok, Pid};
+        Error ->
+            ok = riak_kv_stat:update(query_create_error),
+            Error
+    end.
+
+
+start_link() ->
+    supervisor:start_link({local, ?MODULE}, ?MODULE, []).
+
+init([]) ->
+    QueryChildSpec =
+        {
+            undefined,
+            {riak_kv_query_worker, query_start, []},
+            temporary,
+            5000,
+            worker,
+            [riak_kv_query_worker]
+        },
+
+    {ok, {{simple_one_for_one, 10, 10}, [QueryChildSpec]}}.

--- a/src/riak_kv_query_sup.erl
+++ b/src/riak_kv_query_sup.erl
@@ -33,9 +33,9 @@
 
 start_query_worker(Node, Args) ->
     case supervisor:start_child({?MODULE, Node}, Args) of
-        {ok, Pid} ->
+        {ok, Pid, ReqID} ->
             ok = riak_kv_stat:update({query_create, Pid}),
-            {ok, Pid};
+            {ok, Pid, ReqID};
         Error ->
             ok = riak_kv_stat:update(query_create_error),
             Error
@@ -49,11 +49,11 @@ init([]) ->
     QueryChildSpec =
         {
             undefined,
-            {riak_kv_query_worker, query_start, []},
+            {riak_kv_query_server, query_start, []},
             temporary,
             5000,
             worker,
-            [riak_kv_query_worker]
+            [riak_kv_query_server]
         },
 
     {ok, {{simple_one_for_one, 10, 10}, [QueryChildSpec]}}.

--- a/src/riak_kv_query_worker.erl
+++ b/src/riak_kv_query_worker.erl
@@ -1,0 +1,512 @@
+%% -------------------------------------------------------------------
+%%
+%% riak_query_worker: Manage complex secondary index query.
+%%
+%% Copyright (c) 2007-2013 Basho Technologies, Inc.  All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
+
+%% @doc The query worker manages a single secondary index query.
+%%
+%% This is a gen_server to manage an individual query.
+%% 
+%% The server will initialise a coverage query, and then await vnodes
+%% returning results.  The server should terminate when:
+%% - all vnodes have returned all results
+%% - sufficient results from all vnodes have been received such that any
+%% further results received would exceed the maximum number of results
+%% - the PID which requested the query dies
+%% - an absolute timeout occurs
+%% 
+%% TODO:
+%% This has not been implemented with the riak_core_coverage_fsm behaviour as
+%% it was considered there was minimal value in that behaviour, and there is a
+%% preference not to complicate future work to remove deprecated gen_fsm
+%% from Riak by expanding its use.
+%% In the future the riak_kv_clusteraae_fsm and riak_index_fsm should be
+%% refactored in line with this - and this may involve re-introducing a
+%% common behaviour.
+
+-module(riak_kv_query_worker).
+
+-behaviour(gen_server).
+
+-define(SLOW_TIME, application:get_env(riak_kv, index_fsm_slow_timems, 200)).
+-define(FAST_TIME, application:get_env(riak_kv, index_fsm_fast_timems, 10)).
+
+-export(
+    [
+        query_start/1,
+        new_timeout/2,
+        check_vnode_monitor/1
+    ]
+).
+
+-export(
+    [
+        init/1,
+        handle_call/3,
+        handle_cast/2,
+        handle_info/2,
+        terminate/2,
+        code_change/3,
+        format_status/1
+    ]
+).
+
+-include_lib("kernel/include/logger.hrl").
+
+-define(VERSION, [{version, 2}]). % to be used in sets
+
+-record(timings, 
+    {
+        start_time = os:timestamp() :: erlang:timestamp(),
+        max = 0 :: non_neg_integer(),
+        min = infinity :: non_neg_integer()|infinity,
+        count = 0 :: non_neg_integer(),
+        sum = 0 :: non_neg_integer(),
+        slow_count = 0 :: non_neg_integer(),
+        fast_count = 0 :: non_neg_integer(),
+        slow_time = ?SLOW_TIME,
+        fast_time = ?FAST_TIME
+    }
+).
+-record(state,
+    {
+        from :: from(),
+        client_monitor :: reference(),
+        timeout_reqid :: req_id(),
+        req_id :: req_id(),
+        timings = #timings{} :: timings(),
+        bucket :: riak_object:bucket(),
+        vnode_monitor :: vnode_monitor(),
+        vnodes_ongoing :: sets:set(vnode_id()),
+        acc :: result_record()|redacted
+    }
+).
+
+-record(count_acc,
+    {
+        results = 0 :: non_neg_integer()
+    }
+).
+-record(key_acc,
+    {
+        results = [] :: key_list(),
+        last_key_monitor :: last_key_monitor()
+    }
+).
+-record(term_acc,
+    {
+        results = [] :: term_list(),
+        last_key_monitor :: last_term_monitor()
+    }
+).
+-record(map_acc,
+    {
+        results = maps:new() :: count_map()
+    }
+).
+
+-type key_list() :: list(riak_object:key()).
+-type term_list() :: list({binary(), riak_object:key()}).
+-type last_key_monitor() :: #{vnode_id() => riak_object:key()|none}.
+-type last_term_monitor() :: #{vnode_id() => {binary(), riak_object:key()}|none}.
+-type count_map() :: #{binary() => non_neg_integer()}|#{}.
+
+-type result_record() :: #count_acc{}|#key_acc{}|#term_acc{}|#map_acc{}.
+-type results() :: key_list()|term_list()|count_map()|non_neg_integer().
+
+-type from() :: {atom(), req_id(), pid()}.
+-type req_id() :: non_neg_integer().
+
+-type timings() :: #timings{}.
+
+-type vnode_id() :: non_neg_integer().
+-type vnode_monitor() :: #{vnode_id() => non_neg_integer()}|#{}.
+
+
+%%%============================================================================
+%%% API
+%%%============================================================================
+
+-spec query_start(
+    riak_kv_query:complex_query_definition())
+        -> {ok, pid(), non_neg_integer()}.
+query_start(Query) ->
+    {ok, Worker} =
+        gen_server:start_link(?MODULE, Query, []),
+    {ok, Worker, riak_kv_query:get_reqid(Query)}.
+
+-spec new_timeout(pid(), pos_integer()) -> ok.
+new_timeout(Pid, SecondsToTimeout) ->
+    gen_server:cast(Pid, {new_timeout, SecondsToTimeout}).
+
+-spec check_vnode_monitor(pid()) -> {ok, vnode_monitor()}.
+check_vnode_monitor(Pid) ->
+    gen_server:call(Pid, {check_progress, vnode_monitor}, infinity).
+
+%%%============================================================================
+%%% gen_server callbacks
+%%%============================================================================
+
+init(Query) ->
+    Bucket = riak_kv_query:get_bucket(Query),
+    BucketProps = riak_core_bucket:get_bucket(Bucket),
+    NVal = proplists:get_value(n_val, BucketProps),
+    R = riak_kv_query:get_r(Query),
+    AccType = riak_kv_query:get_accumulator(Query),
+    EvaluatedQuery = riak_kv_query:get_query_definition(Query),
+    Request =
+        riak_kv_requests:new_query_request(
+            Bucket,
+            none,
+            riak_kv_query:get_querytype(Query),
+            AccType,
+            riak_kv_query:get_returnterms(Query),
+            calculate_buffer_size(Query),
+            EvaluatedQuery),
+    TimeoutS = riak_kv_query:get_timeout_secs(Query),
+    From = riak_kv_query:get_clientpid(Query),
+    ReqID = riak_kv_query:get_reqid(Query),
+    ClientMonitorRef = erlang:monitor(process, From),
+    case riak_core_coverage_plan:create_plan(all, NVal, R, ReqID, riak_kv) of
+        {error, Reason} ->
+            ?LOG_WARNING("Query coverage plan failed due to ~0p", [Reason]),
+            From ! {ReqID, {error, insufficient_vnodes}},
+            {stop, insufficient_vnodes};
+        {CoverageVnodes, FilterVnodes} ->
+            Sender = {raw, ReqID, self()},
+            riak_core_vnode_master:coverage(
+                Request,
+                CoverageVnodes,
+                FilterVnodes,
+                Sender,
+                riak_kv_vnode_master
+            ),
+            InitMonitor = maps:from_keys(CoverageVnodes, 0),
+            VnodesOngoing = sets:from_list(CoverageVnodes, ?VERSION),
+            Acc =
+                case AccType of
+                    keys ->
+                        LKM = maps:from_keys(CoverageVnodes, none),
+                        #key_acc{last_key_monitor = LKM};
+                    term_with_keys ->
+                        LKTM = maps:from_keys(CoverageVnodes, none),
+                        #term_acc{last_key_monitor = LKTM};
+                    match_count ->
+                        #count_acc{};
+                    key_count ->
+                        #count_acc{};
+                    term_with_matchcount ->
+                        #map_acc{};
+                    term_with_keycount ->
+                        #map_acc{}
+                    end,
+            erlang:send_after(TimeoutS * 1000, self(), {timeout, ReqID}),
+            {
+                ok, 
+                #state{
+                    from = {raw, ReqID, From},
+                    client_monitor = ClientMonitorRef,
+                    timeout_reqid = ReqID,
+                    req_id = ReqID,
+                    bucket = Bucket,
+                    vnode_monitor = InitMonitor,
+                    vnodes_ongoing = VnodesOngoing,
+                    acc = Acc
+                }
+            }
+    end.
+
+handle_cast({new_timeout, SecondsToTimeout}, State) ->
+    ReqID = riak_kv_query:get_reqid(),
+    erlang:send_after(SecondsToTimeout * 1000, self(), {timeout, ReqID}),
+    {noreply, State#state{timeout_reqid = ReqID}}.
+
+handle_call({check_progress, vnode_monitor}, _From, State) ->
+    {reply, {ok, State#state.vnode_monitor}, State}.
+
+handle_info({timeout, ReqID}, #state{timeout_reqid = ReqID} = State) ->
+    {raw, ReqID, From} = State#state.from,
+    From ! {ReqID, {error, timeout}},
+    ?LOG_WARNING("Query terminated due to timeout"),
+    {stop, shutdown, State};
+handle_info(
+    {{ReqID, Vnode}, {From, _B, ping}}, #state{req_id = ReqID} = State) ->
+    riak_kv_vnode:ack_keys(From),
+    {
+        noreply,
+        State#state{
+            vnode_monitor = update_monitor(Vnode, State#state.vnode_monitor)}
+    };
+handle_info(
+        {{ReqID, Vnode}, {From, _B, {keys, Results}}}, 
+        #state{req_id = ReqID} = State) ->
+    riak_kv_vnode:ack_keys(From),
+    ?LOG_INFO("Received result size ~w ack'd to ~0p", [length(Results), From]),
+    {keys, UpdResults} =
+        riak_kv_query_buffer:aggregate(
+            {keys, Results},
+            {keys, (State#state.acc)#key_acc.results}
+        ),
+    UpdLKM =
+        case UpdResults of
+            ActualList when is_list(ActualList), length(ActualList) > 0 ->
+                LastKey = lists:last(UpdResults),
+                maps:update(
+                    Vnode, LastKey, (State#state.acc)#key_acc.last_key_monitor
+                );
+            _ ->
+                (State#state.acc)#key_acc.last_key_monitor
+        end,
+    {
+        noreply,
+        State#state{
+            vnode_monitor = update_monitor(Vnode, State#state.vnode_monitor),
+            acc = #key_acc{results = UpdResults, last_key_monitor = UpdLKM}
+        }
+    };
+handle_info(
+        {{ReqID, Vnode}, {From, _B, {term_with_keys, Results}}},
+        #state{req_id = ReqID} = State) ->
+    riak_kv_vnode:ack_keys(From),
+    {term_with_keys, UpdResults} =
+        riak_kv_query_buffer:aggregate(
+            {term_with_keys, Results},
+            {term_with_keys, (State#state.acc)#term_acc.results}
+        ),
+        UpdLKM =
+            case UpdResults of
+                ActualList when is_list(ActualList), length(ActualList) > 0 ->
+                    LastTerm = lists:last(UpdResults),
+                    maps:update(
+                        Vnode, LastTerm, (State#state.acc)#term_acc.last_key_monitor
+                    );
+                _ ->
+                    (State#state.acc)#term_acc.last_key_monitor
+            end,
+    {
+        noreply,
+        State#state{
+            vnode_monitor = update_monitor(Vnode, State#state.vnode_monitor),
+            acc = #term_acc{results = UpdResults, last_key_monitor = UpdLKM}
+        }
+    };
+handle_info(
+        {{ReqID, Vnode}, {From, _B, {match_count, Count}}},
+        #state{req_id = ReqID} = State) ->
+    riak_kv_vnode:ack_keys(From),
+    {match_count, UpdResults} =
+        riak_kv_query_buffer:aggregate(
+            {match_count, Count},
+            {match_count, (State#state.acc)#count_acc.results}
+        ),
+    {
+        noreply,
+        State#state{
+            vnode_monitor = update_monitor(Vnode, State#state.vnode_monitor),
+            acc = #count_acc{results = UpdResults}
+        }
+    };
+handle_info(
+        {{ReqID, Vnode}, {From, _B, {key_count, Count}}},
+        #state{req_id = ReqID} = State) ->
+    riak_kv_vnode:ack_keys(From),
+    {key_count, UpdResults} =
+        riak_kv_query_buffer:aggregate(
+            {key_count, Count},
+            {key_count, (State#state.acc)#count_acc.results}
+        ),
+    {
+        noreply,
+        State#state{
+            vnode_monitor = update_monitor(Vnode, State#state.vnode_monitor),
+            acc = #count_acc{results = UpdResults}
+        }
+    };
+handle_info(
+        {{ReqID, Vnode}, {From, _B, {term_with_matchcount, RM}}},
+        #state{req_id = ReqID} = State) ->
+    riak_kv_vnode:ack_keys(From),
+    {term_with_matchcount, UpdResults} =
+        riak_kv_query_buffer:aggregate(
+            {term_with_matchcount, RM},
+            {term_with_matchcount, (State#state.acc)#map_acc.results}
+        ),
+    {
+        noreply,
+        State#state{
+            vnode_monitor = update_monitor(Vnode, State#state.vnode_monitor),
+            acc = #map_acc{results = UpdResults}
+        }
+    };
+handle_info(
+        {{ReqID, Vnode}, {From, _B, {term_with_keycount, RM}}},
+        #state{req_id = ReqID} = State) ->
+    riak_kv_vnode:ack_keys(From),
+    {term_with_keycount, UpdResults} =
+        riak_kv_query_buffer:aggregate(
+            {term_with_keycount, RM},
+            {term_with_keycount, (State#state.acc)#map_acc.results}
+        ),
+    {
+        noreply,
+        State#state{
+            vnode_monitor = update_monitor(Vnode, State#state.vnode_monitor),
+            acc = #map_acc{results = UpdResults}
+        }
+    };
+handle_info(
+    {{ReqID, Vnode}, done}, #state{req_id = ReqID} = State) ->
+    UpdCoverageVnodes = sets:del_element(Vnode, State#state.vnodes_ongoing),
+    UpdTimings = update_timings(State#state.timings),
+    case sets:size(UpdCoverageVnodes) of
+        0 ->
+            {Results, ResultsSent} =
+                case extract_results(State#state.acc) of
+                    RL when is_list(RL) ->
+                        {RL, length(RL)};
+                    RC when is_integer(RC) ->
+                        {RC, RC};
+                    RM when is_map(RM) ->
+                        {RM, lists:sum(maps:values(RM))}
+                end,
+            {raw, ClientReqID, ClientPid} = State#state.from,
+            ?LOG_INFO("Returning response ~0p", [Results]),
+            ClientPid ! {ClientReqID, Results},
+            log_timings(
+                UpdTimings,
+                State#state.bucket,
+                ResultsSent
+            ),
+            {stop, normal, State};
+        _ ->
+            ?LOG_INFO(
+                "Query done for ~w remainining ~w",
+                [Vnode, sets:size(UpdCoverageVnodes)]
+            ),
+            {
+                noreply,
+                State#state{
+                    timings = UpdTimings,
+                    vnode_monitor =
+                        update_monitor(Vnode, State#state.vnode_monitor),
+                    vnodes_ongoing = UpdCoverageVnodes
+                }
+            }
+    end;
+handle_info(
+        {'DOWN', CMR, process, Pid, _Info},
+        #state{client_monitor = CMR} = State) ->
+    ?LOG_WARNING("Query terminated due to client=~w termination", [Pid]),
+    {stop, shutdown, State};
+handle_info(Msg, State) ->
+    ?LOG_INFO("Receieved unexpected message ~0p", [Msg]),
+    {noreply, State}.
+
+terminate(_Reason, _State) ->
+    ok.
+
+    
+format_status(Status) ->
+    case maps:get(reason, Status, normal) of
+        terminate ->
+            State = maps:get(state, Status),
+            maps:update(
+                state,
+                State#state{acc = redacted},
+                Status
+            );
+        _ ->
+            Status
+    end.
+
+code_change(_OldVsn, State, _Extra) ->
+    {ok, State}.
+
+
+%%%============================================================================
+%%% Internal functions
+%%%============================================================================
+
+-spec update_monitor(vnode_id(), vnode_monitor()) -> vnode_monitor().
+update_monitor(Vnode, VnodeMonitor) ->
+    maps:update_with(Vnode, fun(V) -> V + 1 end, VnodeMonitor).
+
+-spec calculate_buffer_size(
+    riak_kv_query:complex_query_definition()) -> pos_integer().
+calculate_buffer_size(_Query) ->
+    %% May need to change when adding support for max_results
+    application:get_env(riak_kv, query_buffer_size, 256).
+
+-spec extract_results(result_record()) -> results().
+extract_results(Acc) when is_record(Acc, key_acc) ->
+    Acc#key_acc.results;
+extract_results(Acc) when is_record(Acc, term_acc) ->
+    Acc#term_acc.results;
+extract_results(Acc) when is_record(Acc, map_acc) ->
+    Acc#map_acc.results;
+extract_results(Acc) when is_record(Acc, count_acc) ->
+    Acc#count_acc.results.
+
+-spec update_timings(timings()) -> timings().
+update_timings(Timings) ->
+    MS = timer:now_diff(os:timestamp(), Timings#timings.start_time) div 1000,
+    SlowCount =
+        case MS > Timings#timings.slow_time of
+            true ->
+                Timings#timings.slow_count + 1;
+            false ->
+                Timings#timings.slow_count
+        end,
+    FastCount = 
+        case MS < Timings#timings.fast_time of
+            true ->
+                Timings#timings.fast_count + 1;
+            false ->
+                Timings#timings.fast_count
+        end,
+    Timings#timings{
+        max = max(Timings#timings.max, MS),
+        min = min(Timings#timings.min, MS),
+        count = Timings#timings.count + 1,
+        sum = Timings#timings.sum + MS,
+        slow_count = SlowCount,
+        fast_count = FastCount 
+    }.
+
+-spec log_timings(timings(), riak_object:bucket(), non_neg_integer()) -> ok.
+log_timings(Timings, Bucket, ResultCount) ->
+    Duration = timer:now_diff(os:timestamp(), Timings#timings.start_time),
+    ok = riak_kv_stat:update({index_fsm_time, Duration, ResultCount}),
+    log_timings(Timings,
+                Bucket,
+                ResultCount,
+                application:get_env(riak_kv, log_index_fsm, false)).
+
+log_timings(_Timings, _Bucket, _ResultCount, false) ->
+    ok;
+log_timings(Timings, Bucket, ResultCount, true) ->
+    ?LOG_INFO("Index query on bucket=~p " ++
+                "max_vnodeq=~w min_vnodeq=~w sum_vnodeq=~w count_vnodeq=~w " ++
+                "slow_count_vnodeq=~w fast_count_vnodeq=~w result_count=~w",
+                [Bucket,
+                    Timings#timings.max, Timings#timings.min,
+                    Timings#timings.sum, Timings#timings.count,
+                    Timings#timings.slow_count, Timings#timings.fast_count,
+                    ResultCount]).

--- a/src/riak_kv_requests.erl
+++ b/src/riak_kv_requests.erl
@@ -29,6 +29,7 @@
          new_listkeys_request/3,
          new_listbuckets_request/1,
          new_index_request/4,
+         new_query_request/7,
          new_vnode_status_request/0,
          new_delete_request/2,
          new_reap_request/2,
@@ -43,6 +44,10 @@
          get_item_filter/1,
          get_ack_backpressure/1,
          get_query/1,
+         get_querytype/1,
+         get_accumulation_type/1,
+         get_return_terms/1,
+         get_buffer_size/1,
          get_object/1,
          get_delete_hash/1,
          get_encoded_obj/1,
@@ -64,6 +69,7 @@
               listkeys_request/0,
               listbuckets_request/0,
               index_request/0,
+              query_request/0,
               vnode_status_request/0,
               delete_request/0,
               reap_request/0,
@@ -81,11 +87,10 @@
 -type request_options() :: [any()].
 -type replica_type() :: primary | fallback.
 -type encoded_obj() :: binary().
--type bucket() :: riak_core_bucket:bucket().
 -type item_filter() :: function().
 -type coverage_filter() :: riak_kv_coverage_filter:filter().
 -type query() :: riak_index:query_def().
--type aae_query() :: riak_kv_clusteraae_fsm:query_definition().
+-type aae_query() :: riak_kv_aaefold:query_definition().
 
 -record(riak_kv_put_req_v1,
         { bkey :: bucket_key(),
@@ -106,27 +111,39 @@
 }).
 
 -record(riak_kv_listkeys_req_v3, {
-          bucket :: bucket(),
+          bucket :: riak_object:bucket(),
           item_filter :: item_filter()}).
 
 %% same as _v3, but triggers ack-based backpressure (we switch on the record *name*)
 -record(riak_kv_listkeys_req_v4, {
-          bucket :: bucket(),
+          bucket :: riak_object:bucket(),
           item_filter :: item_filter()}).
 
 -record(riak_kv_listbuckets_req_v1, {
           item_filter :: item_filter()}).
 
 -record(riak_kv_index_req_v1, {
-          bucket :: bucket(),
+          bucket :: riak_object:bucket(),
           item_filter :: coverage_filter(),
           qry :: query()}).
 
 %% same as _v1, but triggers ack-based backpressure
 -record(riak_kv_index_req_v2, {
-          bucket :: bucket(),
+          bucket :: riak_object:bucket(),
           item_filter :: coverage_filter(),
           qry :: riak_index:query_def()}).
+
+-record(riak_kv_complexquery_req_v1,
+    {
+        bucket :: riak_object:bucket(),
+        item_filter :: coverage_filter(),
+        query_type :: riak_kv_query:query_type(),
+        acc_type :: riak_kv_query:accumulation_option(),
+        return_terms :: binary()|boolean(),
+        buffer_size :: pos_integer(),
+        query :: riak_kv_query:query_definition()
+    }
+).
 
 -record(riak_kv_vnode_status_req_v1, {}).
 
@@ -151,7 +168,7 @@
           req_id :: non_neg_integer()}).
 
 -record(riak_kv_aaefold_req_v1, 
-            {qry :: riak_kv_clusteraae_fsm:query_definition(),
+            {qry :: aae_query(),
                 init_acc :: any(),
                 n_val :: pos_integer()}).
 
@@ -164,6 +181,7 @@
 -opaque listbuckets_request() :: #riak_kv_listbuckets_req_v1{}.
 -opaque listkeys_request() :: #riak_kv_listkeys_req_v3{} | #riak_kv_listkeys_req_v4{}.
 -opaque index_request() :: #riak_kv_index_req_v1{} | #riak_kv_index_req_v2{}.
+-opaque query_request() :: #riak_kv_complexquery_req_v1{}.
 -opaque vnode_status_request() :: #riak_kv_vnode_status_req_v1{}.
 -opaque delete_request() :: #riak_kv_delete_req_v1{}.
 -opaque reap_request() :: #riak_kv_reap_req_v1{}.
@@ -180,6 +198,7 @@
                  | listkeys_request()
                  | listbuckets_request()
                  | index_request()
+                 | query_request()
                  | vnode_status_request()
                  | delete_request()
                  | reap_request()
@@ -195,6 +214,7 @@
                       | kv_listkeys_request
                       | kv_listbuckets_request
                       | kv_index_request
+                      | kv_query_request
                       | kv_vnode_status_request
                       | kv_delete_request
                       | kv_reap_request
@@ -214,6 +234,7 @@ request_type(#riak_kv_listkeys_req_v4{})-> kv_listkeys_request;
 request_type(#riak_kv_listbuckets_req_v1{})-> kv_listbuckets_request;
 request_type(#riak_kv_index_req_v1{})-> kv_index_request;
 request_type(#riak_kv_index_req_v2{})-> kv_index_request;
+request_type(#riak_kv_complexquery_req_v1{})-> kv_query_request;
 request_type(#riak_kv_vnode_status_req_v1{})-> kv_vnode_status_request;
 request_type(#riak_kv_delete_req_v1{})-> kv_delete_request;
 request_type(#riak_kv_reap_req_v1{}) -> kv_reap_request;
@@ -248,7 +269,10 @@ new_head_request(BKey, ReqId) ->
 new_w1c_put_request(BKey, EncodedObj, ReplicaType) ->
     #riak_kv_w1c_put_req_v1{bkey = BKey, encoded_obj = EncodedObj, type = ReplicaType}.
 
--spec new_listkeys_request(bucket(), item_filter(), UseAckBackpressure::boolean()) -> listkeys_request().
+-spec new_listkeys_request(
+    riak_object:bucket(),
+    item_filter(),
+    UseAckBackpressure::boolean()) -> listkeys_request().
 new_listkeys_request(Bucket, ItemFilter, true) ->
     #riak_kv_listkeys_req_v4{bucket=Bucket,
                              item_filter=ItemFilter};
@@ -256,9 +280,10 @@ new_listkeys_request(Bucket, ItemFilter, false) ->
     #riak_kv_listkeys_req_v3{bucket=Bucket,
                              item_filter=ItemFilter}.
 
--spec new_aaefold_request(aae_query(),
-                            any(),
-                            pos_integer()) -> aaefold_request().
+-spec new_aaefold_request(
+    aae_query(),
+    any(),
+    pos_integer()) -> aaefold_request().
 new_aaefold_request(Query, InitAcc, NVal) ->
     #riak_kv_aaefold_req_v1{qry = Query, init_acc = InitAcc, n_val = NVal}.
 
@@ -270,11 +295,11 @@ new_hotbackup_request(BackupPath) ->
 new_listbuckets_request(ItemFilter) ->
     #riak_kv_listbuckets_req_v1{item_filter=ItemFilter}.
 
--spec new_index_request(bucket(),
-                        coverage_filter(),
-                        riak_index:query_def(),
-                        UseAckBackpressure::boolean())
-                       -> index_request().
+-spec new_index_request(
+    riak_object:bucket(),
+    coverage_filter(),
+    riak_index:query_def(),
+    UseAckBackpressure::boolean()) -> index_request().
 new_index_request(Bucket, ItemFilter, Query, false) ->
     #riak_kv_index_req_v1{bucket=Bucket,
                          item_filter=ItemFilter,
@@ -283,6 +308,26 @@ new_index_request(Bucket, ItemFilter, Query, true) ->
     #riak_kv_index_req_v2{bucket=Bucket,
                           item_filter=ItemFilter,
                           qry=Query}.
+
+-spec new_query_request(
+    riak_object:bucket(),
+    coverage_filter(),
+    riak_kv_query:query_type(),
+    riak_kv_query:accumulation_option(),
+    binary()|boolean(),
+    pos_integer(),
+    riak_kv_query:query_definition()) -> query_request().
+new_query_request(
+        Bucket, ItemFilter, Type, AccType, ReturnTerms, BuffSize, Query) ->
+    #riak_kv_complexquery_req_v1{
+        bucket = Bucket,
+        item_filter = ItemFilter,
+        query_type = Type,
+        acc_type = AccType,
+        return_terms = ReturnTerms,
+        buffer_size = BuffSize,
+        query = Query
+    }.
 
 -spec new_vnode_status_request() -> vnode_status_request().
 new_vnode_status_request() ->
@@ -326,7 +371,7 @@ get_bucket_key(#riak_kv_reap_req_v1{bkey = BKey}) ->
 get_bucket_keys(#riak_kv_vclock_req_v1{bkeys = BKeys}) ->
     BKeys.
 
--spec get_bucket(request()) -> bucket().
+-spec get_bucket(request()) -> riak_object:bucket().
 get_bucket(#riak_kv_listkeys_req_v3{bucket = Bucket}) ->
     Bucket;
 get_bucket(#riak_kv_listkeys_req_v4{bucket = Bucket}) ->
@@ -334,6 +379,8 @@ get_bucket(#riak_kv_listkeys_req_v4{bucket = Bucket}) ->
 get_bucket(#riak_kv_index_req_v1{bucket = Bucket}) ->
     Bucket;
 get_bucket(#riak_kv_index_req_v2{bucket = Bucket}) ->
+    Bucket;
+get_bucket(#riak_kv_complexquery_req_v1{bucket = Bucket}) ->
     Bucket.
 
 
@@ -347,6 +394,8 @@ get_item_filter(#riak_kv_listbuckets_req_v1{item_filter = ItemFilter}) ->
 get_item_filter(#riak_kv_index_req_v1{item_filter = ItemFilter}) ->
     ItemFilter;
 get_item_filter(#riak_kv_index_req_v2{item_filter = ItemFilter}) ->
+    ItemFilter;
+get_item_filter(#riak_kv_complexquery_req_v1{item_filter = ItemFilter}) ->
     ItemFilter.
 
 -spec get_ack_backpressure(listkeys_request()|index_request())
@@ -360,13 +409,32 @@ get_ack_backpressure(#riak_kv_index_req_v1{}) ->
 get_ack_backpressure(#riak_kv_index_req_v2{}) ->
     true.
 
--spec get_query(request()) -> query()|aae_query().
+-spec get_query(
+    request()) -> query()|aae_query()|riak_kv_query:query_definition().
 get_query(#riak_kv_index_req_v1{qry = Query}) ->
     Query;
 get_query(#riak_kv_index_req_v2{qry = Query}) ->
     Query;
 get_query(#riak_kv_aaefold_req_v1{qry = Query}) ->
+    Query;
+get_query(#riak_kv_complexquery_req_v1{query = Query}) ->
     Query.
+
+-spec get_querytype(request()) -> riak_kv_query:query_type().
+get_querytype(#riak_kv_complexquery_req_v1{query_type = QT}) ->
+    QT.
+
+-spec get_accumulation_type(request()) -> riak_kv_query:accumulation_option().
+get_accumulation_type(#riak_kv_complexquery_req_v1{acc_type = ATY}) ->
+    ATY.
+
+-spec get_return_terms(request()) -> binary()|boolean().
+get_return_terms(#riak_kv_complexquery_req_v1{return_terms = RT}) ->
+    RT.
+
+-spec get_buffer_size(request()) -> pos_integer().
+get_buffer_size(#riak_kv_complexquery_req_v1{buffer_size = BS}) ->
+    BS.
 
 -spec get_encoded_obj(request()) -> encoded_obj().
 get_encoded_obj(#riak_kv_w1c_put_req_v1{encoded_obj = EncodedObj}) ->

--- a/src/riak_kv_stat.erl
+++ b/src/riak_kv_stat.erl
@@ -343,6 +343,14 @@ do_update({index_create, Pid}) ->
     ok;
 do_update(index_create_error) ->
     exometer:update([?PFX, ?APP, index, fsm, create, error], 1);
+do_update({query_create, Pid}) ->
+    P = ?PFX,
+    ok = exometer:update([P, ?APP, query, fsm, create], 1),
+    ok = exometer:update([P, ?APP, query, fsm, active], 1),
+    add_monitor(query, Pid),
+    ok;
+do_update(query_create_error) ->
+    exometer:update([?PFX, ?APP, query, fsm, create, error], 1);
 do_update({clusteraae_create, Pid}) ->
     P = ?PFX,
     ok = exometer:update([P, ?APP, clusteraae, fsm, create], 1),
@@ -801,6 +809,34 @@ stats() ->
      {[clusteraae, fsm, create], spiral, [], [{one, clusteraae_fsm_create}]},
      {[clusteraae, fsm, create, error], spiral, [], [{one, clusteraae_fsm_create_error}]},
      {[clusteraae, fsm, active], counter, [], [{value, clusteraae_fsm_active}]},
+     {[query, fsm, create], spiral, [], [{one, query_fsm_create}]},
+     {[query, fsm, create, error], spiral, [], [{one, query_fsm_create_error}]},
+     {[query, fsm, active], counter, [], [{value, query_fsm_active}]},
+     {[query, fsm, complete], spiral, [], [{one, query_fsm_complete}]},
+     {
+        [query, fsm, results],
+        histogram,
+        [], 
+        [
+            {mean  , query_fsm_results_mean},
+            {median, query_fsm_results_median},
+            {95    , query_fsm_results_95},
+            {99    , query_fsm_results_99},
+            {max   , query_fsm_results_100}
+        ]
+    },
+     {
+        [query, fsm, time],
+        histogram,
+        [],
+        [
+            {mean , query_fsm_time_mean},
+            {median, query_fsm_time_median},
+            {95    , query_fsm_time_95},
+            {99    , query_fsm_time_99},
+            {max   , query_fsm_time_100}
+        ]
+    },
 
      %% misc stats
      {mapper_count, counter, [], [{value, executing_mappers}]},

--- a/src/riak_kv_stat.erl
+++ b/src/riak_kv_stat.erl
@@ -270,6 +270,15 @@ do_update({index_fsm_time, Microsecs, ResultCount}) ->
     ok = exometer:update([P, ?APP, index, fsm, complete], 1),
     ok = exometer:update([P, ?APP, index, fsm, results], ResultCount),
     ok = exometer:update([P, ?APP, index, fsm, time], Microsecs);
+do_update({query_node_time, Microsecs, ResultCount}) ->
+    P = ?PFX,
+    ok = exometer:update([P, ?APP, query, node, complete], 1),
+    ok = exometer:update([P, ?APP, query, node, results], ResultCount),
+    ok = exometer:update([P, ?APP, query, node, time], Microsecs);
+do_update({query_vnode_time, Microsecs}) ->
+    P = ?PFX,
+    ok = exometer:update([P, ?APP, query, vnode, complete], 1),
+    ok = exometer:update([P, ?APP, query, vnode, time], Microsecs);
 do_update({read_repairs, Preflist}) ->
     ok = exometer:update([?PFX, ?APP, node, gets, read_repairs], 1),
     do_repairs(Preflist);
@@ -345,12 +354,11 @@ do_update(index_create_error) ->
     exometer:update([?PFX, ?APP, index, fsm, create, error], 1);
 do_update({query_create, Pid}) ->
     P = ?PFX,
-    ok = exometer:update([P, ?APP, query, fsm, create], 1),
-    ok = exometer:update([P, ?APP, query, fsm, active], 1),
+    ok = exometer:update([P, ?APP, query, server, create], 1),
     add_monitor(query, Pid),
     ok;
 do_update(query_create_error) ->
-    exometer:update([?PFX, ?APP, query, fsm, create, error], 1);
+    exometer:update([?PFX, ?APP, query, server, create, error], 1);
 do_update({clusteraae_create, Pid}) ->
     P = ?PFX,
     ok = exometer:update([P, ?APP, clusteraae, fsm, create], 1),
@@ -809,32 +817,40 @@ stats() ->
      {[clusteraae, fsm, create], spiral, [], [{one, clusteraae_fsm_create}]},
      {[clusteraae, fsm, create, error], spiral, [], [{one, clusteraae_fsm_create_error}]},
      {[clusteraae, fsm, active], counter, [], [{value, clusteraae_fsm_active}]},
-     {[query, fsm, create], spiral, [], [{one, query_fsm_create}]},
-     {[query, fsm, create, error], spiral, [], [{one, query_fsm_create_error}]},
-     {[query, fsm, active], counter, [], [{value, query_fsm_active}]},
-     {[query, fsm, complete], spiral, [], [{one, query_fsm_complete}]},
+     {[query, server, create], spiral, [], [{one, query_server_create}]},
+     {[query, server, create, error], spiral, [], [{one, query_server_create_error}]},
+     {[query, node, complete], spiral, [], [{one, node_query}, {count, node_query_total}]},
      {
-        [query, fsm, results],
+        [query, node, results],
         histogram,
         [], 
         [
-            {mean  , query_fsm_results_mean},
-            {median, query_fsm_results_median},
-            {95    , query_fsm_results_95},
-            {99    , query_fsm_results_99},
-            {max   , query_fsm_results_100}
+            {mean  , node_query_results_mean},
+            {median, node_query_results_median},
+            {max   , node_query_results_100}
         ]
     },
      {
-        [query, fsm, time],
+        [query, node, time],
         histogram,
         [],
         [
-            {mean , query_fsm_time_mean},
-            {median, query_fsm_time_median},
-            {95    , query_fsm_time_95},
-            {99    , query_fsm_time_99},
-            {max   , query_fsm_time_100}
+            {mean ,  node_query_time_mean},
+            {median, node_query_time_median},
+            {99,     node_query_time_99},
+            {max   , node_query_time_100}
+        ]
+    },
+    {[query, vnode, complete], spiral, [], [{one, vnode_query}]},
+     {
+        [query, vnode, time],
+        histogram,
+        [],
+        [
+            {mean ,  vnode_query_time_mean},
+            {median, vnode_query_time_median},
+            {99,     vnode_query_time_99},
+            {max   , vnode_query_time_100}
         ]
     },
 

--- a/src/riak_kv_sup.erl
+++ b/src/riak_kv_sup.erl
@@ -64,6 +64,12 @@ init([]) ->
     IndexFsmSup = {riak_kv_index_fsm_sup,
                    {riak_kv_index_fsm_sup, start_link, []},
                    permanent, infinity, supervisor, [riak_kv_index_fsm_sup]},
+    QuerySup = 
+        {
+            riak_kv_query_sup,
+            {riak_kv_query_sup, start_link, []},
+            permanent, infinity, supervisor, [riak_kv_query_sup]
+        },
     ClusterAAEFsmSup = {riak_kv_clusteraae_fsm_sup,
                    {riak_kv_clusteraae_fsm_sup, start_link, []},
                    permanent, infinity, supervisor, [riak_kv_clusteraae_fsm_sup]},
@@ -122,6 +128,7 @@ init([]) ->
         BucketsFsmSup,
         KeysFsmSup,
         IndexFsmSup,
+        QuerySup,
         ClusterAAEFsmSup,
         HotBackupAAEFsmSup,
         [EnsemblesKV || riak_core_sup:ensembles_enabled()],

--- a/src/riak_kv_ttaaefs_manager.erl
+++ b/src/riak_kv_ttaaefs_manager.erl
@@ -1059,10 +1059,10 @@ local_sender({fetch_clocks_range, B0, KR, SF, MR}, C, ReturnFun, _NVal) ->
     run_localfold({fetch_clocks_range, B0, KR, SF, LMR}, C, ReturnFun).
 
 
--spec run_localfold(riak_kv_clusteraae_fsm:query_definition(),
-                        riak_client:riak_client(),
-                        fun((any()) -> ok)) -> 
-                            fun(() -> ok).
+-spec run_localfold(
+    riak_kv_aaefold:query_definition(),
+    riak_client:riak_client(),
+    fun((any()) -> ok)) ->  fun(() -> ok).
 run_localfold(Query, Client, ReturnFun) ->
     fun() ->
         case riak_client:aae_fold(Query, Client) of

--- a/src/riak_kv_vnode.erl
+++ b/src/riak_kv_vnode.erl
@@ -3588,7 +3588,6 @@ result_fun_ack(Bucket, Sender) ->
             riak_core_vnode:reply(Sender, {{self(), Monitor}, Bucket, Items}),
             receive
                 {Monitor, ok} ->
-                    ?LOG_INFO("Received Ack at Sender ~0p", [Sender]),
                     erlang:demonitor(Monitor, [flush]);
                 {Monitor, stop_fold} ->
                     erlang:demonitor(Monitor, [flush]),
@@ -3615,14 +3614,12 @@ stop_fold({Pid, Ref}) ->
 %% @private
 finish_fun(BufferMod, Sender) ->
     fun(Buffer) ->
-        ?LOG_INFO("Finsh fold, send to ~0p", [Sender]),
         finish_fold(BufferMod, Buffer, Sender)
     end.
 
 %% @private
 finish_fold(BufferMod, Buffer, Sender) ->
     BufferMod:flush(Buffer),
-    ?LOG_INFO("Results flushed - reply to Sender ~0p with done", [Sender]),
     riak_core_vnode:reply(Sender, done).
 
 %% @private

--- a/src/riak_kv_vnode.erl
+++ b/src/riak_kv_vnode.erl
@@ -1690,10 +1690,53 @@ handle_coverage_request(kv_aaefold_request, Req, FilterVNodes, Sender, State) ->
     Query = riak_kv_requests:get_query(Req),
     InitAcc = riak_kv_requests:get_initacc(Req),
     Nval = riak_kv_requests:get_nval(Req),
-    handle_coverage_aaefold(Query, InitAcc, Nval, 
-                            FilterVNodes, Sender, 
-                            State);
+    handle_coverage_aaefold(
+        Query, InitAcc, Nval, FilterVNodes, Sender, State);
+handle_coverage_request(kv_query_request, Req, FilterVNodes, Sender, State) ->
+    Bucket = riak_kv_requests:get_bucket(Req),
+    Query = riak_kv_requests:get_query(Req),
+    AccType = riak_kv_requests:get_accumulation_type(Req),
+    ReturnTerms = riak_kv_requests:get_return_terms(Req),
+    BufferSize = riak_kv_requests:get_buffer_size(Req),
+    ResultFun = result_fun_ack(Bucket, Sender),
+    BufferMod = riak_kv_query_buffer,    
+    Buffer = riak_kv_query_buffer:new(BufferSize, AccType, ResultFun),
+    BackendMod = State#state.mod,
+    {ok, Capabilities} = BackendMod:capabilities(State#state.modstate),
+    Opts =
+        maybe_enable_async_fold(State#state.async_folding, Capabilities, []),
 
+    FilterVNode = proplists:get_value(State#state.idx, FilterVNodes),
+    Filter = 
+        riak_kv_coverage_filter:build_filter(
+            Bucket,
+            riak_kv_requests:get_item_filter(Req),
+            FilterVNode
+        ),
+    % Build the fold and finish functions
+    Extras = fold_extras_keys(State#state.idx, Bucket),
+    FoldFun = fold_fun(keys, BufferMod, Filter, Extras),
+    FinishFun = finish_fun(BufferMod, Sender),
+    case lists:member(complex_query, Capabilities) of
+        true ->
+            Work = 
+                BackendMod:complex_query(
+                    FoldFun,
+                    Buffer,
+                    Bucket,
+                    Query,
+                    ReturnTerms,
+                    Opts,
+                    State#state.modstate),
+            case Work of
+                {ok, Acc} ->
+                    FinishFun(Acc);
+                {async, AsyncWork} ->
+                    {async, {fold, AsyncWork, FinishFun}, Sender, State}
+            end;
+        false ->
+            {reply, {error, {queries_not_supported, BackendMod}}, State}
+    end;
 handle_coverage_request(kv_hotbackup_request, Req, _FilterVnodes, Sender,
                 State=#state{mod=Mod, modstate=ModState}) ->
     % If the backend is hot_backup capability, run the backup via the node
@@ -3545,13 +3588,15 @@ result_fun_ack(Bucket, Sender) ->
             riak_core_vnode:reply(Sender, {{self(), Monitor}, Bucket, Items}),
             receive
                 {Monitor, ok} ->
+                    ?LOG_INFO("Received Ack at Sender ~0p", [Sender]),
                     erlang:demonitor(Monitor, [flush]);
                 {Monitor, stop_fold} ->
                     erlang:demonitor(Monitor, [flush]),
                     throw(stop_fold);
                 {'DOWN', Monitor, process, Pid, Reason} ->
-                    ?LOG_ERROR("Process ~w down for reason ~w", 
-                                    [Pid, Reason]),
+                    ?LOG_ERROR(
+                        "Process ~w down for reason ~w",  [Pid, Reason]
+                    ),
                     throw(receiver_down)
             end
     end.
@@ -3570,12 +3615,14 @@ stop_fold({Pid, Ref}) ->
 %% @private
 finish_fun(BufferMod, Sender) ->
     fun(Buffer) ->
-            finish_fold(BufferMod, Buffer, Sender)
+        ?LOG_INFO("Finsh fold, send to ~0p", [Sender]),
+        finish_fold(BufferMod, Buffer, Sender)
     end.
 
 %% @private
 finish_fold(BufferMod, Buffer, Sender) ->
     BufferMod:flush(Buffer),
+    ?LOG_INFO("Results flushed - reply to Sender ~0p with done", [Sender]),
     riak_core_vnode:reply(Sender, done).
 
 %% @private

--- a/src/riak_kv_web.erl
+++ b/src/riak_kv_web.erl
@@ -120,6 +120,9 @@ raw_dispatch(Name) ->
      {Prefix ++ ["buckets", bucket, "index", field, '*'],
       riak_kv_wm_index, Props},
 
+     {Prefix ++ ["buckets", bucket, "query"],
+      riak_kv_wm_query, Props},
+
      %% AAE fold URLs
      {["cachedtrees", "nvals", nval, "root"],
       riak_kv_wm_aaefold, Props},

--- a/src/riak_kv_wm_query.erl
+++ b/src/riak_kv_wm_query.erl
@@ -1,0 +1,842 @@
+%% -------------------------------------------------------------------
+%%
+%% Copyright (c) 2007-2016 Basho Technologies, Inc.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
+
+%% @doc Webmachine resource for running queries on secondary indexes.
+%%
+%% Available operations:
+%%
+%% ```
+%% POST types/BucketType/buckets/Bucket/query
+%% ```
+%%
+%% The query should be posted as the HTTP body, where there are the following
+%% JSON keys at the root of the document
+%% 
+%% - aggregation_expression (optional)
+%% If multiple queries are to be run, the aggregation expression is used to
+%% inform the database how those results should be combined, using $1, $2 etc
+%% to refer to the numeric aggregation_tag for each query - with the key words
+%% UNION, INTERSECT and SUBTRACT to show how the sets of results are to be
+%% combined.  Parenthesis may be used for clarity.
+%% e.g. ($1 INTERSECT $2) UNION ($3 SUBTRACT $1)
+%% 
+%% - accumulation_option (optional - default = keys)
+%% There are six options for accumulating the results from a single query: 
+%% keys (return a list of keys), term_with_keys (return a list of term/key
+%% tuples), match_count (return a count of the matches made), key_count (return
+%% a count of unique keys matched), term_with_matchcount/term_with_keycount
+%% (return a map of term to either count of matches, or count of unique keys).
+%% If an aggregation_expression is used, only keys, key_count and match_count
+%% can be used.
+%% 
+%% - accumulation_term (optional - default = $term)
+%% When using an accumulation option of term_with_keys, term_with_matchcount or
+%% term_with_keycount which term in the evaluated index term should be used.
+%% The defualt is $term - the whole term.  However a sub-term extracted in the
+%% evaluation expression may be used instead.  
+%% 
+%% - result_provision (not yet implemented)
+%% 
+%% - max_results (not yet implemented)
+%% 
+%% - term_rate_kpersec (not yet implemented)
+%% 
+%% - substitutions (optional)
+%% A array of key/value pairs that match string that are referred to in queries
+%% to substitution values that should replace those keys in the query.
+%% e.g. {"low_dob" : "19550301", "high_dob" : "19560630"} can be passed as
+%% substitutions to populate an evaluation of
+%% "$dob" BETWEEN ":low_dob" AND ":high_dob"
+%% 
+%% - timeout (optional)
+%% The timeout in seconds to wait for the query to complete
+%% 
+%% - query_list
+%% A list of queries (should be a list of just one query if an
+%% aggregation_expression is not used).
+%% Each query has the following parts:
+%% - aggregation_tag (optional unless an aggregation_expression is used)
+%% - index_name (should be a binary index)
+%% - start_term
+%% - end_term
+%% - regular expression (optional alternative to using evaluation or filter
+%%  expressions)
+%% - evaluation_expression (optional, an expression to extract projected
+%% attributes from the term)
+%% - filter_expression (optional, an expression to filter results based on
+%% those projected attributes)
+ 
+-module(riak_kv_wm_query).
+
+-include_lib("webmachine/include/webmachine.hrl").
+-include("riak_kv_wm_raw.hrl").
+
+%% webmachine resource exports
+-export([
+    init/1,
+    service_available/2,
+    is_authorized/2,
+    forbidden/2,
+    allowed_methods/2,
+    malformed_request/2,
+    resource_exists/2,
+    process_post/2
+]).
+
+-record(ctx, {
+          client,       %% riak_client() - the store client
+          riak,         %% local | {node(), atom()} - params for riak client
+          bucket_type,  %% Bucket type (from uri)
+          query,        %% The query..
+          security,     %% security context
+          accumulation_option
+         }).
+-type context() :: #ctx{}.
+-type request_data() :: #wm_reqdata{}.
+
+-define(AGGREGATION_EXPRESSION, <<"aggregation_expression">>).
+-define(ACCUMULATION_OPTION, <<"accumulation_option">>).
+-define(ACCUMULATION_TERM, <<"accumulation_term">>).
+-define(SUBSTITUTIONS, <<"substitutions">>).
+-define(TIMEOUT, <<"timeout">>).
+-define(QUERY_LIST, <<"query_list">>).
+-define(QL_AGGREGATION_TAG, <<"aggregation_tag">>).
+-define(QL_INDEX_NAME, <<"index_name">>).
+-define(QL_START_TERM, <<"start_term">>).
+-define(QL_END_TERM, <<"end_term">>).
+-define(QL_REGULAR_EXPRESSION, <<"regular_expression">>).
+-define(QL_EVALUATION_EXPRESSION, <<"evaluation_expression">>).
+-define(QL_FILTER_EXPRESSION, <<"filter_expression">>).
+
+-define(ACCKEY_KEYS, <<"keys">>).
+-define(ACCKEY_TERMKEYS, <<"term_with_keys">>).
+-define(ACCKEY_KEYCOUNT, <<"key_count">>).
+-define(ACCKEY_MATCHCOUNT, <<"match_count">>).
+-define(ACCKEY_TERMMATCHCOUNT, <<"term_with_matchcount">>).
+-define(ACCKEY_TERMKEYCOUNT, <<"term_with_keycount">>).
+
+-define(REQUIRED_KEYS, [?QUERY_LIST]).
+-define(POSSIBLE_KEYS,
+    [
+        ?AGGREGATION_EXPRESSION,
+        ?ACCUMULATION_OPTION,
+        ?ACCUMULATION_TERM,
+        ?SUBSTITUTIONS,
+        ?TIMEOUT,
+        ?QUERY_LIST
+    ]
+).
+-define(REQUIRED_QL_KEYS,
+    [
+        ?QL_INDEX_NAME,
+        ?QL_START_TERM,
+        ?QL_END_TERM
+    ]
+).
+-define(POSSIBLE_QL_KEYS,
+    [
+        ?QL_AGGREGATION_TAG,
+        ?QL_INDEX_NAME,
+        ?QL_START_TERM,
+        ?QL_END_TERM,
+        ?QL_REGULAR_EXPRESSION,
+        ?QL_EVALUATION_EXPRESSION,
+        ?QL_FILTER_EXPRESSION
+    ]
+).
+
+-define(REQUEST_CLASS, {riak_kv, secondary_index}).
+
+-define(QUERY_TIMEOUT, 60).
+
+-type query_map() ::
+    #{binary() => binary()|non_neg_integer()|list(map())}.
+
+
+-spec init(proplists:proplist()) -> {ok, context()}.
+%% @doc Initialize this resource.
+init(Props) ->
+    {ok, #ctx{
+       riak=proplists:get_value(riak, Props),
+       bucket_type=proplists:get_value(bucket_type, Props)
+      }}.
+
+
+-spec service_available(request_data(), context()) ->
+    {boolean(), request_data(), context()}.
+%% @doc Determine whether or not a connection to Riak
+%%      can be established. Also, extract query params.
+service_available(RD, Ctx0=#ctx{riak=RiakProps}) ->
+    Ctx = riak_kv_wm_utils:ensure_bucket_type(RD, Ctx0, #ctx.bucket_type),
+    case riak_kv_wm_utils:get_riak_client(RiakProps, riak_kv_wm_utils:get_client_id(RD)) of
+        {ok, C} ->
+            {true, RD, Ctx#ctx { client=C }};
+        Error ->
+            {false,
+             wrq:set_resp_body(
+               io_lib:format("Unable to connect to Riak: ~p~n", [Error]),
+               wrq:set_resp_header(?HEAD_CTYPE, "text/plain", RD)),
+             Ctx}
+    end.
+
+resource_exists(RD, #ctx{bucket_type=BType}=Ctx) ->
+    {riak_kv_wm_utils:bucket_type_exists(BType), RD, Ctx}.
+    
+-spec is_authorized(request_data(), context()) ->
+    {true | string() | {halt, 426}, request_data(), context()}.
+is_authorized(ReqData, Ctx) ->
+    case riak_api_web_security:is_authorized(ReqData) of
+        false ->
+            {"Basic realm=\"Riak\"", ReqData, Ctx};
+        {true, SecContext} ->
+            {true, ReqData, Ctx#ctx{security=SecContext}};
+        insecure ->
+            %% XXX 301 may be more appropriate here, but since the http and
+            %% https port are different and configurable, it is hard to figure
+            %% out the redirect URL to serve.
+            {
+                {halt, 426},
+                wrq:append_to_resp_body(
+                    <<"Security is enabled and "
+                    "Riak does not accept credentials over HTTP. Try HTTPS "
+                    "instead.">>,
+                    ReqData
+                ),
+                Ctx
+            }
+    end.
+
+-spec forbidden(request_data(), context())
+        -> {boolean(), request_data(), context()}.
+forbidden(ReqDataIn, #ctx{security = undefined} = Context) ->
+    riak_kv_wm_utils:is_forbidden(ReqDataIn, ?REQUEST_CLASS, Context);
+forbidden(ReqDataIn, #ctx{bucket_type = BT, security = Sec} = Context) ->
+    {Answer, ReqData, _} = Result =
+        riak_kv_wm_utils:is_forbidden(ReqDataIn, ?REQUEST_CLASS, Context),
+    case Answer of
+        false ->
+            Bucket = erlang:list_to_binary(
+                riak_kv_wm_utils:maybe_decode_uri(
+                    ReqData, wrq:path_info(bucket, ReqData))),
+            case riak_core_security:check_permission(
+                    {"riak_kv.index", {BT, Bucket}}, Sec) of
+                {false, Error, _} ->
+                    {true,
+                        wrq:append_to_resp_body(
+                            unicode:characters_to_binary(Error, utf8, utf8),
+                            wrq:set_resp_header(
+                                "Content-Type", "text/plain", ReqData)),
+                        Context};
+                {true, _} ->
+                    {false, ReqData, Context}
+            end;
+        _ ->
+            Result
+    end.
+
+-spec allowed_methods(
+    request_data(), context()) -> {list(atom()), request_data(), context()}.
+allowed_methods(RD, Ctx) ->
+    {['POST'], RD, Ctx}.
+
+-spec malformed_request(
+    request_data(), context()) ->
+        {boolean(), request_data(), context()}.
+malformed_request(RD, Ctx) ->
+    Bucket =
+        list_to_binary(
+            riak_kv_wm_utils:maybe_decode_uri(RD, wrq:path_info(bucket, RD)
+        )
+    ),
+    BT = riak_kv_wm_utils:maybe_bucket_type(Ctx#ctx.bucket_type, Bucket),
+    Body = riak_kv_wm_utils:accept_value("application/json", wrq:req_body(RD)),
+    case decode_json_body(Body) of
+        {ok, QueryMap} ->
+            case check_keys(maps:keys(QueryMap), request) of
+                ok ->
+                    QueryList = maps:get(?QUERY_LIST, QueryMap),
+                    case check_querylist(QueryList, false) of
+                        ok ->
+                            case make_query(BT, QueryMap) of
+                                {ok, Query} ->
+                                    {false, RD, Ctx#ctx{query = Query}};
+                                {error, Stage, Reason} ->
+                                    {
+                                        true,
+                                        return_json_error(
+                                            expand_query_reason(Stage, Reason),
+                                            RD
+                                        ),
+                                        Ctx
+                                    }
+                                end;
+                        {error, Reason} ->
+                            {true, return_json_error(Reason, RD), Ctx}
+                    end;
+                {error, Reason} ->
+                    {true, return_json_error(Reason, RD), Ctx}
+            end;
+        {error, Reason} ->
+            {true, return_json_error(Reason, RD), Ctx}
+    end.
+
+expand_query_reason(Stage, Reason) ->
+    lists:flatten(
+        io_lib:format(
+            << "Validation failure at stage ~0p due to ~s">>, 
+            [Stage, Reason]
+        )
+    ).
+
+-spec return_json_error(string(), request_data()) -> request_data().
+return_json_error(Reason, RD) ->
+    wrq:append_to_resp_body(
+        riak_kv_wm_json:encode(#{error => Reason}),
+        wrq:set_resp_header(
+            ?HEAD_CTYPE, "application/json", RD
+        )
+    ).
+
+-spec decode_json_body(binary()) -> {ok, map()}| {error, term()}.
+decode_json_body(JsonBody) ->
+    try
+        DecodedBody = riak_kv_wm_json:decode(JsonBody),
+        {ok, DecodedBody}
+    catch
+        error:Reason ->
+            ExpandedReason =
+                lists:flatten(
+                    io_lib:format(
+                        <<"Malformed json request - ~0p">>, 
+                        [Reason]
+                    )
+                ),
+            {error, ExpandedReason}
+    end.
+
+check_querylist([], true) ->
+    ok;
+check_querylist([], false) ->
+    {error, <<"No valid query provided">>};
+check_querylist([HdQuery|Rest], _AtLeastOne) ->
+    case check_keys(maps:keys(HdQuery), query) of
+        ok ->
+            check_querylist(Rest, true);
+        Error ->
+            Error
+    end.
+
+check_keys(Keys, request) ->
+    check_keys(Keys, ?REQUIRED_KEYS, ?POSSIBLE_KEYS);
+check_keys(Keys, query) ->
+    check_keys(Keys, ?REQUIRED_QL_KEYS, ?POSSIBLE_QL_KEYS).
+
+-spec check_keys(
+    list(binary()), list(binary()), list(binary())) -> ok|{error, string()}.
+check_keys(Keys, RequiredKeys, PossibleKeys) ->
+    RequiredKeyList =
+        lists:filter(
+            fun(K) -> lists:member(K, Keys) end,
+            RequiredKeys
+        ),
+    PossibleKeyList =
+        lists:filter(
+            fun(K) -> lists:member(K, PossibleKeys) end,
+            Keys
+        ),
+    case RequiredKeyList of
+        RequiredKeys ->
+            case PossibleKeyList of
+                Keys ->
+                    ok;
+                NotAllKeys ->
+                    ExtraKeys = lists:subtract(Keys, NotAllKeys),
+                    {
+                        error,
+                        lists:flatten(
+                            io_lib:format(
+                                <<"Unexpected keys in request ~0p">>,
+                                [ExtraKeys]
+                            )
+                        )
+                    }
+            end;
+        NotAllRequiredKeys ->
+            MissingKeys = lists:subtract(RequiredKeys, NotAllRequiredKeys),
+            {
+                error,
+                lists:flatten(
+                    io_lib:format(
+                        <<"Missing required keys in request ~0p">>,
+                        [MissingKeys]
+                    )
+                )
+            }
+    end.
+
+-spec make_query(
+    riak_object:bucket(), query_map()) ->
+        {ok, riak_kv_query:complex_query_definition()}|riak_kv_query:validation_error().
+make_query(BucketType, QueryMap) ->
+    Timeout =
+        maps:get(
+            ?TIMEOUT,
+            QueryMap,
+            application:get_env(riak_kv, query_timeout_secs, ?QUERY_TIMEOUT)
+        ),
+    case Timeout of
+        T when is_integer(T), T > 0 ->
+            InitQuery =
+                case maps:get(?QUERY_LIST, QueryMap) of
+                    QueryList when length(QueryList) == 1 ->
+                        riak_kv_query:new(BucketType, single_query, Timeout);
+                    QueryList when length(QueryList) > 1 ->
+                        riak_kv_query:new(BucketType, combo_query, Timeout)
+                end,
+            case make_accumulation(QueryMap, InitQuery) of
+                {ok, Q1} ->
+                    AggExpr =
+                        maps:get(
+                            ?AGGREGATION_EXPRESSION, QueryMap, undefined
+                        ),
+                    case riak_kv_query:add_aggregation_expression(Q1, AggExpr) of
+                        {ok, Q2} ->
+                            Subs =
+                                maps:get(?SUBSTITUTIONS, QueryMap, maps:new()),
+                            riak_kv_query:add_queries(
+                                Q2, 
+                                lists:map(fun convert_query/1, QueryList),
+                                Subs
+                            );
+                        Error ->
+                            Error
+                    end;
+                Error ->
+                    Error
+            end;
+        _ ->
+            {error, init, <<"Bad timeout">>}
+    end.
+                    
+-spec make_accumulation(
+    query_map(), riak_kv_query:complex_query_definition())
+        -> 
+            {ok, riak_kv_query:complex_query_definition()} |
+            riak_kv_query:validation_error().
+make_accumulation(QueryMap, InitQuery) ->
+    AccOpt = maps:get(?ACCUMULATION_OPTION, QueryMap, undefined),
+    AccTerm = maps:get(?ACCUMULATION_TERM, QueryMap, undefined),
+    case riak_kv_query:add_accumulation_option(InitQuery, AccOpt) of
+        {ok, UpdQuery} ->
+            riak_kv_query:add_accumulation_term(UpdQuery, AccTerm);
+        Error ->
+            Error
+    end.
+
+-spec convert_query(map()) -> riak_kv_query:query_user_input().
+convert_query(QM) ->
+    {
+        maps:get(<<"aggregation_tag">>, QM, undefined),
+        maps:get(<<"index_name">>, QM),
+        maps:get(<<"start_term">>, QM),
+        maps:get(<<"end_term">>, QM),
+        maps:get(<<"regular_expression">>, QM, undefined),
+        maps:get(<<"evaluation_expression">>, QM, undefined),
+        maps:get(<<"filter_expression">>, QM, undefined)
+    }.
+
+-spec process_post(request_data(), context()) ->
+    {boolean()|{halt, pos_integer()}, request_data(), context()}.
+%% @doc Produce the JSON response to an index lookup.
+process_post(RD, Ctx) ->
+    Query = Ctx#ctx.query,
+    Client = Ctx#ctx.client,
+    AccOpt = riak_kv_query:get_accumulator(Query),
+    case riak_client:query(Query, Client) of
+        {error, timeout} ->
+            {{halt, 503}, return_json_error("timeout", RD), Ctx};
+        Results ->
+            JsonEncodedResults = encode_results(AccOpt, Results),
+            {
+                true,
+                wrq:append_to_resp_body(
+                    JsonEncodedResults,
+                    wrq:set_resp_header(?HEAD_CTYPE, "application/json", RD)
+                ),
+                Ctx
+            }
+    end.
+
+-spec encode_results(
+    riak_kv_query:accumulation_option(),
+    riak_kv_query_server:results() | {error, term()}) ->
+        binary().
+encode_results(AccOpt, {error, Reason}) ->
+    iolist_to_binary(
+        lists:flatten(
+            io_lib:format(
+                <<"Query with option ~w failed - ~0p">>,
+                [AccOpt, Reason]
+            )
+        )
+    );
+encode_results(keys, Results) ->
+    iolist_to_binary(
+        riak_kv_wm_json:encode(
+            #{?ACCKEY_KEYS => Results},
+            fun riak_kv_wm_index:keys_encode/2
+        )
+    );
+encode_results(term_with_keys, Results) ->
+    iolist_to_binary(
+        riak_kv_wm_json:encode(
+            #{?ACCKEY_TERMKEYS => Results},
+            fun riak_kv_wm_index:results_encode/2
+        )
+    );
+encode_results(match_count, Count) ->
+    iolist_to_binary(
+        riak_kv_wm_json:encode(#{?ACCKEY_MATCHCOUNT => Count})
+    );
+encode_results(key_count, Count) ->
+    iolist_to_binary(
+        riak_kv_wm_json:encode(#{?ACCKEY_KEYCOUNT => Count})
+    );
+encode_results(term_with_matchcount, CountMap) ->
+    iolist_to_binary(
+        riak_kv_wm_json:encode(#{?ACCKEY_TERMMATCHCOUNT => CountMap})
+    );
+encode_results(term_with_keycount, CountMap) ->
+    iolist_to_binary(
+        riak_kv_wm_json:encode(#{?ACCKEY_TERMKEYCOUNT => CountMap})
+    ).
+
+%% ===================================================================
+%% EUnit tests
+%% ===================================================================
+
+-ifdef(TEST).
+
+-include_lib("eunit/include/eunit.hrl").
+
+invalid_json_test() ->
+    InvalidJson =
+        <<"
+            {
+                \"accumulation_option\" : \"keys\",
+                \"timeout\" : 60,
+                \"query_list\" :
+                    [
+                        {
+                            \"index_name\" : \"example_bin\"
+                            \"start_term\" : \"A\",
+                            \"end_term\"   : \"B\"
+                        }
+                    ]
+            }
+        ">>, % Missing comma after example_bin
+    R = decode_json_body(InvalidJson),
+    io:format("~p~n", [R]),
+    ?assertMatch(
+        {error, "Malformed json request - {invalid_byte,34}"},
+        R
+    ).
+
+simple_query_test() ->
+    SimpleQueryJson =
+        <<"
+            {
+                \"timeout\" : 60,
+                \"query_list\" :
+                    [
+                        {
+                            \"index_name\" : \"example_bin\",
+                            \"start_term\" : \"A\",
+                            \"end_term\"   : \"B\"
+                        }
+                    ]
+            }
+        ">>,
+    {ok, M} = decode_json_body(SimpleQueryJson),
+    {ok, Q} = make_query({<<"BT">>, <<"B">>}, M),
+    ?assert(riak_kv_query:is_query(Q)).
+
+invalid_query_ae1_test() ->
+    IQJson =
+        <<"
+            {
+                \"aggregation_expression\" : \"$1 INTERSECT $2\",
+                \"timeout\" : 60,
+                \"query_list\" :
+                    [
+                        {
+                            \"index_name\" : \"example_bin\",
+                            \"start_term\" : \"A\",
+                            \"end_term\"   : \"B\"
+                        }
+                    ]
+            }
+        ">>,
+    {ok, M} = decode_json_body(IQJson),
+    {error, S, _E} = make_query({<<"BT">>, <<"B">>}, M),
+    ?assertMatch(aggregation_expression, S).
+
+invalid_query_ae2_test() ->
+    IQJson =
+        <<"
+            {
+                \"timeout\" : 60,
+                \"query_list\" :
+                    [
+                        {
+                            \"aggregation_tag\" : 1,
+                            \"index_name\" : \"example_bin\",
+                            \"start_term\" : \"A\",
+                            \"end_term\"   : \"B\"
+                        },
+                        {
+                            \"aggregation_tag\" : 2,
+                            \"index_name\" : \"example_bin\",
+                            \"start_term\" : \"A\",
+                            \"end_term\"   : \"B\"
+                        }
+
+                    ]
+            }
+        ">>,
+    {ok, M} = decode_json_body(IQJson),
+    {error, S, _E} = make_query({<<"BT">>, <<"B">>}, M),
+    ?assertMatch(aggregation_expression, S).
+
+invalid_query_ae3_test() ->
+    IQJson =
+        <<"
+            {
+                \"aggregation_expression\" : \"$1 INTERSECT $2\",
+                \"timeout\" : 60,
+                \"query_list\" :
+                    [
+                        {
+                            \"index_name\" : \"example_bin\",
+                            \"start_term\" : \"A\",
+                            \"end_term\"   : \"B\"
+                        },
+                        {
+                            \"aggregation_tag\" : 2,
+                            \"index_name\" : \"example_bin\",
+                            \"start_term\" : \"A\",
+                            \"end_term\"   : \"B\"
+                        }
+
+                    ]
+            }
+        ">>,
+    {ok, M} = decode_json_body(IQJson),
+    {error, S, E} = make_query({<<"BT">>, <<"B">>}, M),
+    ?assertMatch(query_evaluation, S),
+    ?assertMatch(<<"Untagged query in combination request">>, E).
+
+valid_query_ae4_test() ->
+    IQJson =
+        <<"
+            {
+                \"aggregation_expression\" : \"$1 INTERSECT $2\",
+                \"timeout\" : 60,
+                \"query_list\" :
+                    [
+                        {
+                            \"aggregation_tag\" : 1,
+                            \"index_name\" : \"example_bin\",
+                            \"start_term\" : \"A\",
+                            \"end_term\"   : \"B\"
+                        },
+                        {
+                            \"aggregation_tag\" : 2,
+                            \"index_name\" : \"example_bin\",
+                            \"start_term\" : \"A\",
+                            \"end_term\"   : \"B\"
+                        }
+
+                    ]
+            }
+        ">>,
+    {ok, M} = decode_json_body(IQJson),
+    {ok, Q} = make_query({<<"BT">>, <<"B">>}, M),
+    ?assert(riak_kv_query:is_query(Q)),
+    QueryList = maps:get(<<"query_list">>, M),
+    ?assertMatch(ok, check_querylist(QueryList, false)).
+
+invalid_query_to_test() ->
+    IQJson =
+        <<"
+            {
+                \"aggregation_expression\" : \"$1 INTERSECT $2\",
+                \"timeout\" : 0,
+                \"query_list\" :
+                    [
+                        {
+                            \"aggregation_tag\" : 1,
+                            \"index_name\" : \"example_bin\",
+                            \"start_term\" : \"A\",
+                            \"end_term\"   : \"B\"
+                        },
+                        {
+                            \"aggregation_tag\" : 2,
+                            \"index_name\" : \"example_bin\",
+                            \"start_term\" : \"A\",
+                            \"end_term\"   : \"B\"
+                        }
+
+                    ]
+            }
+        ">>,
+    {ok, M} = decode_json_body(IQJson),
+    {error, S, E} = make_query({<<"BT">>, <<"B">>}, M),
+    ?assertMatch(init, S),
+    ?assertMatch(<<"Bad timeout">>, E).
+
+invalid_query_extratag_test() ->
+    IQJson =
+        <<"
+            {
+                \"aggregation_expression\" : \"$1 INTERSECT $2\",
+                \"timeout\" : 60,
+                \"subs\" : {\"dob\" : \"19260812\"},
+                \"query_list\" :
+                    [
+                        {
+                            \"aggregation_tag\" : 1,
+                            \"index_name\" : \"example_bin\",
+                            \"start_term\" : \"A\",
+                            \"end_term\"   : \"B\"
+                        },
+                        {
+                            \"aggregation_tag\" : 2,
+                            \"index_name\" : \"example_bin\",
+                            \"start_term\" : \"A\",
+                            \"end_term\"   : \"B\",
+                            \"end_key\"   : \"B\"
+                        }
+
+                    ]
+            }
+        ">>,
+    {ok, M} = decode_json_body(IQJson),
+    ?assertMatch(
+        {error, "Unexpected keys in request [<<\"subs\">>]"},
+        check_keys(maps:keys(M), request)
+    ),
+    ?assertMatch(
+        {error, "Unexpected keys in request [<<\"end_key\">>]"},
+        check_querylist(maps:get(<<"query_list">>, M), false)
+    ).
+
+invalid_query_missingtag1_test() ->
+    IQJson =
+        <<"
+            {
+                \"aggregation_expression\" : \"$1 INTERSECT $2\",
+                \"timeout\" : 60,
+                \"subs\" : {\"dob\" : \"19260812\"}
+            }
+        ">>,
+    {ok, M} = decode_json_body(IQJson),
+    ?assertMatch(
+        {error, "Missing required keys in request [<<\"query_list\">>]"},
+        check_keys(maps:keys(M), request)
+    ).
+    
+invalid_query_missingtag2_test() ->
+    IQJson =
+        <<"
+            {
+                \"aggregation_expression\" : \"$1 INTERSECT $2\",
+                \"timeout\" : 60,
+                \"query_list\" :
+                    [
+                        {
+                            \"aggregation_tag\" : 1,
+                            \"index_name\" : \"example_bin\",
+                            \"start_term\" : \"A\",
+                            \"end_term\"   : \"B\"
+                        },
+                        {
+                            \"aggregation_tag\" : 2,
+                            \"index_name\" : \"example_bin\",
+                            \"end_term\"   : \"B\"
+                        }
+
+                    ]
+            }
+        ">>,
+    {ok, M} = decode_json_body(IQJson),
+    ?assertMatch(
+        {error, "Missing required keys in request [<<\"start_term\">>]"},
+        check_querylist(maps:get(<<"query_list">>, M), false)
+    ).
+
+encode_results_test() ->
+    BinMC = encode_results(match_count, 500),
+    ?assertMatch(
+        500,
+        maps:get(?ACCKEY_MATCHCOUNT, riak_kv_wm_json:decode(BinMC))
+    ),
+    BinKC = encode_results(key_count, 600),
+    ?assertMatch(
+        600,
+        maps:get(?ACCKEY_KEYCOUNT, riak_kv_wm_json:decode(BinKC))
+    ),
+    KeyList = [<<"K00001">>, <<"K00002">>, <<"K0003">>],
+    BinKL = encode_results(keys, KeyList),
+    ?assertMatch(
+        KeyList,
+        maps:get(?ACCKEY_KEYS, riak_kv_wm_json:decode(BinKL))
+    ),
+    TermKeyList = [{<<"T0001">>, <<"K0002">>}, {<<"T0002">>, <<"K0001">>}],
+    BinTKL = encode_results(term_with_keys, TermKeyList),
+    ?assertMatch(
+        TermKeyList,
+        lists:sort(
+            lists:map(
+                fun(M) -> [{T, K}] = maps:to_list(M), {T, K} end,
+                maps:get(?ACCKEY_TERMKEYS, riak_kv_wm_json:decode(BinTKL))
+            )
+        )
+    ),
+    TermCount = #{<<"T0001">> => 12, <<"T0002">> => 10},
+    BinTKC = encode_results(term_with_keycount, TermCount),
+    ?assertMatch(
+        10,
+        maps:get(
+            <<"T0002">>,
+            maps:get(?ACCKEY_TERMKEYCOUNT, riak_kv_wm_json:decode(BinTKC))
+        )
+    ),
+    BinTMC = encode_results(term_with_matchcount, TermCount),
+    ?assertMatch(
+        12,
+        maps:get(
+            <<"T0001">>,
+            maps:get(?ACCKEY_TERMMATCHCOUNT, riak_kv_wm_json:decode(BinTMC))
+        )
+    )
+    .
+
+-endif.

--- a/src/riak_kv_yessir_backend.erl
+++ b/src/riak_kv_yessir_backend.erl
@@ -178,12 +178,13 @@ api_version() ->
     {ok, ?API_VERSION}.
 
 %% @doc Return the capabilities of the backend.
--spec capabilities(state()) -> {ok, [atom()]}.
+-spec capabilities(state()) -> {ok, [riak_kv_backend:capability()]}.
 capabilities(_) ->
     {ok, ?CAPABILITIES}.
 
 %% @doc Return the capabilities of the backend.
--spec capabilities(riak_object:bucket(), state()) -> {ok, [atom()]}.
+-spec capabilities(
+    riak_object:bucket(), state()) -> {ok, [riak_kv_backend:capability()]}.
 capabilities(_, _) ->
     {ok, ?CAPABILITIES}.
 
@@ -329,10 +330,12 @@ fold_keys(FoldKeysFun, Accum, Opts, State) ->
     end.
 
 %% @doc Fold over all the objects for one or all buckets, yes, sir!
--spec fold_objects(riak_kv_backend:fold_objects_fun(),
-                   any(),
-                   [{atom(), term()}],
-                   state()) -> {ok, any()} | {async, fun()}.
+-spec fold_objects(
+    riak_kv_backend:fold_objects_fun(),
+    any(),
+    [{atom(), term()}],
+    state()) ->
+        {ok, any()} | {async, fun(() -> riak_kv_backend:fold_acc())}.
 fold_objects(FoldObjectsFun, Accum, Opts, State) ->
     KeyCount = State#state.key_count,
     ValueSize = State#state.default_size,


### PR DESCRIPTION
Add support for new query API.

The riak_kv_query module allows a query to be constructed with validation checks.

The riak_kv_query_server is a gen_server for managing a query.  The coverage_fsm behaviour is not used, to aid future migration from the deprecated fsm.

There is a riak_kv_query_buffer added to replace the use of riak_kv_fold_buffer - which assumes the accumulator is a list.