### PR TITLE
Nhse o34 orkv.i58 refactor

### DIFF
--- a/src/riak_kv_http_cache.erl
+++ b/src/riak_kv_http_cache.erl
@@ -12,7 +12,12 @@
 
 -define(SERVER, ?MODULE).
 
--record(st, {ts, stats = []}).
+-record(st,
+    {
+        ts :: undefined|erlang:timestamp(),
+        stats = []
+    }
+).
 
 start_link() ->
     gen_server:start_link({local, ?MODULE}, ?MODULE, [], []).
@@ -40,14 +45,17 @@ code_change(_, S, _) ->
     {ok, S}.
 
 check_cache(#st{ts = undefined} = S) ->
-    S#st{ts = os:timestamp(), stats = do_get_stats()};
+    Stats = do_get_stats(),
+    S#st{ts = os:timestamp(), stats = Stats};
 check_cache(#st{ts = Then} = S) ->
+    CacheTime = application:get_env(riak_kv, http_stats_cache_seconds, 1),
     Now = os:timestamp(),
-    case timer:now_diff(Now, Then) < 1000000 of
-	true ->
-	    S;
-	false ->
-	    S#st{ts = Now, stats = do_get_stats()}
+    case timer:now_diff(Now, Then) < (CacheTime * 1000000) of
+        true ->
+            S;
+        false ->
+            Stats = do_get_stats(),
+            S#st{ts = os:timestamp(), stats = Stats}
     end.
 
 do_get_stats() ->

--- a/src/riak_kv_stat.erl
+++ b/src/riak_kv_stat.erl
@@ -1006,7 +1006,6 @@ bc_stats(Pfx) ->
                           {sys_global_heaps_size, ?MODULE, value, [deprecated]},
                           {sys_heap_type, erlang, system_info, [heap_type]},
                           {sys_logical_processors, erlang, system_info, [logical_processors]},
-                          {sys_monitor_count, riak_kv_stat_bc, sys_monitor_count, []},
                           {sys_otp_release, riak_kv_stat_bc, otp_release, []},
                           {sys_port_count, erlang, system_info, [port_count]},
                           {sys_process_count, erlang, system_info, [process_count]},

--- a/src/riak_kv_stat_bc.erl
+++ b/src/riak_kv_stat_bc.erl
@@ -195,18 +195,6 @@ system_version() ->
 system_architecture() ->
     list_to_binary(erlang:system_info(system_architecture)).
 
-%% Count up all monitors, unfortunately has to obtain process_info
-%% from all processes to work it out.
-sys_monitor_count() ->
-    lists:foldl(fun(Pid, Count) ->
-                        case erlang:process_info(Pid, monitors) of
-                            {monitors, Mons} ->
-                                Count + length(Mons);
-                            _ ->
-                                Count
-                        end
-                end, 0, processes()).
-
 app_stats() ->
     [{list_to_atom(atom_to_list(A) ++ "_version"), list_to_binary(V)}
      || {A,_,V} <- application:which_applications()].

--- a/src/riak_kv_util.erl
+++ b/src/riak_kv_util.erl
@@ -52,7 +52,8 @@
         is_modfun_allowed/2,
         shuffle_list/1,
         kv_ready/0,
-        ngr_initial_timeout/0
+        ngr_initial_timeout/0,
+        sys_monitor_count/0
     ]).
 -export([report_hashtree_tokens/0, reset_hashtree_tokens/2]).
 
@@ -714,7 +715,24 @@ get_initial_call(P) ->
         _ ->
             undefined
     end.
-    
+
+%% @doc sys_monitor_count/0
+%% Count up all monitors, unfortunately has to obtain process_info
+%% from all processes to work it out.
+sys_monitor_count() ->
+    lists:foldl(
+        fun(Pid, Count) ->
+                case erlang:process_info(Pid, monitors) of
+                    {monitors, Mons} ->
+                        Count + length(Mons);
+                    _ ->
+                        Count
+                end
+        end,
+        0, processes()
+    ).
+
+
 %% ===================================================================
 %% EUnit tests
 %% ===================================================================


### PR DESCRIPTION
https://github.com/OpenRiak/riak_kv/issues/58

Changes:

- Updates the cache, so that the timestamp of the stats in the cache, is the timestamp when the stats are returned and not the timestamp when the stats were requested. This protects against a backlog at the cache all requiring stats fetches as the fetch is taking longer than 1s.. The cache time is also now an environment variable.
- Refactor the riak_kv_status:aliases/0 function to loop more efficiently without the multitude of calls to orddict:append/3 which feature in the eprof profile of the stats call. This change still requests the value for a list of datapoints under the key, as opposed to separate fetches - to avoid, for example, multiple functional calls to get vnodeq stats. The change relies on exometer_alias:prefic_foldl/3 being an ordered fold.
- Remove altogether the sys monitor count from the standard stats. The cost of doing this far outweighs the benefit. The function to produce the stats is moved to riak_kv_util module with other troubleshooting functions should someone wish to call it manually.  It has been confirmed that known timeouts in production directly related to this stat.
- Increases the default timeout on the call to the riak_kv_http_cache, make it configurable within the query, and reports a more friendly error back to the operator when the timeout hits (rather than Erlang stacktrace).